### PR TITLE
Bring Document Checking Service styling in line with GOV.UK

### DIFF
--- a/source/central/gds/dcs-pilot/index.html.md.erb
+++ b/source/central/gds/dcs-pilot/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: GOV.UK Document Checking Service Pilot API
+title: Document Checking Service pilot API
 weight: 29
 ---
 
-# GOV.UK Document Checking Service Pilot API
+# Document Checking Service pilot API
 
 **API Base URL links:**
 
@@ -16,7 +16,7 @@ weight: 29
 
 **API Description:**
 
-The Document Checking Service (DCS) Pilot is for non-public sector organisations that want to find out if British passports are valid.
+The Document Checking Service (DCS) pilot is for non-public sector organisations that want to find out if British passports are valid.
 The DCS acts as an interface between a service and HM Passport Office.
 Your service sends a passport check request to the DCS.
 The DCS validates the request and sends it to HM Passport Office.

--- a/source/central/gds/index.html.md.erb
+++ b/source/central/gds/index.html.md.erb
@@ -14,5 +14,5 @@ The API catalogue contains the following Government Digital Service (GDS) APIs:
 - [GOV.UK Search API](search/#gov-uk-search-api)
 - [GOV.UK Organisations API](organisations/#gov-uk-organisations-api)
 - [GOV.UK Governments API](governments/#gov-uk-governments-api)
-- [GOV.UK Document Checking Service Pilot API](dcs-pilot/#gov-uk-document-checking-service-pilot-api)
+- [Document Checking Service pilot API](dcs-pilot/#gov-uk-document-checking-service-pilot-api)
 - [GOV.UK World locations API](world-locations/#gov-uk-world-locations-api)


### PR DESCRIPTION
## What

Bring the styling for the Document Checking Service (DCS) in line with [content on GOV.UK](https://www.gov.uk/guidance/apply-for-the-document-checking-service-pilot-scheme) and the [DCS pilot tech docs](https://dcs-pilot-docs.cloudapps.digital) by:

* removing the 'GOV.UK' prefix
* not capitalising 'pilot'

## Why

So product branding in the API Catalogue is consistent with content published on GOV.UK and other places like tech docs.