### PR TITLE
Updates to the Environment Agency API info

### DIFF
--- a/source/central/ea/flood/index.html.md.erb
+++ b/source/central/ea/flood/index.html.md.erb
@@ -28,4 +28,4 @@ These APIs are provided as open data under the Open Government Licence with no r
 
 _this uses Environment Agency flood and river level data from the real-time data API (Beta)_
 
-For questions on the APIs please contact data.info@environment-agency.gov.uk
+Please visit the [Defra Data Services Forum](https://support.environment.data.gov.uk/hc/en-gb) to let us know about any issues or to ask questions.

--- a/source/central/ea/rain/index.html.md.erb
+++ b/source/central/ea/rain/index.html.md.erb
@@ -25,4 +25,4 @@ These APIs are provided as open data under the Open Government Licence with no r
 
 _this uses Environment Agency rainfall data from the real-time data API (Beta)_
 
-For questions on the APIs please contact [data.info@environment-agency.gov.uk](data.info@environment-agency.gov.uk).
+Please visit the [Defra Data Services Forum](https://support.environment.data.gov.uk/hc/en-gb) to let us know about any issues or to ask questions.

--- a/source/central/ea/tide/index.html.md.erb
+++ b/source/central/ea/tide/index.html.md.erb
@@ -25,4 +25,4 @@ These APIs are provided as open data under the Open Government Licence with no r
 
 _this uses Environment Agency tide gauge data from the real-time data API (Beta)_
 
-For questions on the APIs please contact data.info@environment-agency.gov.uk.
+Please visit the [Defra Data Services Forum](https://support.environment.data.gov.uk/hc/en-gb) to let us know about any issues or to ask questions.


### PR DESCRIPTION
I have changed the way that people can get more information from an email address to a link to the Defra Data Services Forum. This is the correct method to get additional support and information. 