### PR TITLE
Remove 'API' from page titles and headings

### DIFF
--- a/source/central/ch/ch/index.html.md.erb
+++ b/source/central/ch/ch/index.html.md.erb
@@ -1,18 +1,18 @@
 ---
-title: Companies House API
+title: Companies House
 weight: 51
 ---
 
-# Companies House API
+# Companies House
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://api.companieshouse.gov.uk/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://developer.companieshouse.gov.uk/api/docs/)
 
- **API Description:**
+ **Description:**
 
  The Companies House API provides access to all of the public data we hold on companies free of charge. This includes information about companies, officers, people of significant control and more.

--- a/source/central/ch/index.html.md.erb
+++ b/source/central/ch/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: APIs in Companies House
+title: Companies House APIs
 weight: 50
 ---
 

--- a/source/central/ch/streaming/index.html.md.erb
+++ b/source/central/ch/streaming/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Companies House Streaming API
+title: Companies House Streaming
 weight: 52
 ---
 
-# Companies House Streaming API
+# Companies House Streaming
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://stream.companieshouse.gov.uk/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://developer-specs.companieshouse.gov.uk/streaming-api/guides/overview)
 
- **API Description:**
+ **Description:**
 
 The Companies House streaming API gives you access to realtime data changes of the information held at Companies House. This delivers the same information that is available through the on-demand REST API GET requests, but instead pushes data to your client as it changes, through a long-running connection that you first establish.
 

--- a/source/central/ea/asset/index.html.md.erb
+++ b/source/central/ea/asset/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Asset Management API
+title: Asset Management
 weight: 64
 ---
 
-# Asset Management API
+# Asset Management
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://environment.data.gov.uk/asset-management/index.html)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://environment.data.gov.uk/asset-management/doc/reference)
 
-**API Description:**
+**Description:**
 
 The Environment Agency maintains records on assets of many types related to environmental activities particularly flood defences, including some assets owned or managed by other bodies. The API provides access to these asset description records along with information on maintenance activities planned for the assets. Only some assets have an associated maintenance schedule.
 

--- a/source/central/ea/bath/index.html.md.erb
+++ b/source/central/ea/bath/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Bathing Water API
+title: Bathing Water
 weight: 65
 ---
 
-# Bathing Water API
+# Bathing Water
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://environment.data.gov.uk/bwq/index.html)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://environment.data.gov.uk/bwq/doc/api-reference-v0.6.html)
 
-**API Description:**
+**Description:**
 
 The Environment Agency collects water quality data each year from May to September, to ensure that designated bathing water sites on the coast and inland are safe and clean for swimming and other activities. We make this data reusable and accessible to developers and to members of the public, by publishing it as linked data.
 

--- a/source/central/ea/catch/index.html.md.erb
+++ b/source/central/ea/catch/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Catchment Data API
+title: Catchment Data
 weight: 66
 ---
 
-# Catchment Data API
+# Catchment Data
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://environment.data.gov.uk/catchment-planning/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://environment.data.gov.uk/catchment-planning/ui/reference)
 
-**API Description:**
+**Description:**
 
 The Catchment Data Explorer (CDE) helps you explore and download information about the water environment. It supports and builds upon the data in the river basin management plans. The Catchment Data API complements this by providing selective programmatic access to the data.
 

--- a/source/central/ea/epr/index.html.md.erb
+++ b/source/central/ea/epr/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Open electronic Public Register (ePR) API
+title: Open electronic Public Register (ePR) 
 weight: 69
 ---
 
-# Open electronic Public Register (ePR) API
+# Open electronic Public Register (ePR) 
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://environment.data.gov.uk/public-register/view/index)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://environment.data.gov.uk/public-register/view/api-reference)
 
-**API Description:**
+**Description:**
 
 The Environment Agency licenses industry, business and individuals to carry out certain activities that have the potential to pollute the environment. When we receive an application for such a licence, we make that application and other relevant information available to the public. We do this before we make the decision of whether to issue the licence, or what conditions we will attach to it.
 

--- a/source/central/ea/flood/index.html.md.erb
+++ b/source/central/ea/flood/index.html.md.erb
@@ -1,15 +1,15 @@
 ---
-title: Flood-monitoring API
+title: Flood-monitoring
 weight: 61
 ---
 
-# Flood-monitoring API
+# Flood-monitoring 
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](http://environment.data.gov.uk/flood-monitoring)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](http://environment.data.gov.uk/flood-monitoring/doc/reference)
 

--- a/source/central/ea/hydro/index.html.md.erb
+++ b/source/central/ea/hydro/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Hydrology API
+title: Hydrology
 weight: 68
 ---
 
 # Hydrology API
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://environment.data.gov.uk/hydrology/landing)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://environment.data.gov.uk/hydrology/doc/reference)
 
-**API Description:**
+**Description:**
 
 The Hydrology API provides access to historic water flow information. It complements the near real-time data provided under /flood-monitoring in that it provides access to a long term archive of quality checked and qualified data.
 

--- a/source/central/ea/index.html.md.erb
+++ b/source/central/ea/index.html.md.erb
@@ -3,7 +3,7 @@ title: APIs in the Environment Agency
 weight: 60
 ---
 
-# APIs in the Environment Agency
+# Environment Agency APIs
 
 The API catalogue contains the following Environment Agency APIs:
 

--- a/source/central/ea/quality/index.html.md.erb
+++ b/source/central/ea/quality/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Water Quality API
+title: Water Quality
 weight: 67
 ---
 
-# Water Quality API
+# Water Quality
 
 **API Base URL links:**
 
 - [Base URL](https://environment.data.gov.uk/water-quality/view/landing)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://environment.data.gov.uk/water-quality/view/doc/reference)
 
-**API Description:**
+**Description:**
 
 The Water Quality Archive provides data on water quality measurements carried out by the Environment Agency. Samples are taken from sampling points round the country and then analysed by laboratories to measure aspects of the water quality or the environment at the sampling point. The archive provides data on these measurements and samples dating from 2000 to present day. It contains 58 million measurements on nearly 4 million samples from 58 thousand sampling points.
 

--- a/source/central/ea/rain/index.html.md.erb
+++ b/source/central/ea/rain/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Rainfall API
+title: Rainfall
 weight: 62
 ---
 
-# Rainfall API
+# Rainfall
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](http://environment.data.gov.uk/flood-monitoring)
 

--- a/source/central/ea/tide/index.html.md.erb
+++ b/source/central/ea/tide/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Tide Gauge API
+title: Tide Gauge
 weight: 63
 ---
 
-# Tide Gauge API
+# Tide Gauge
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](http://environment.data.gov.uk/flood-monitoring)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](http://environment.data.gov.uk/flood-monitoring/doc/tidegauge)
 
-**API Description:**
+**Description:**
 
 The UK National Tide Gauge Network is owned and operated by the Environment Agency on behalf of the UK Coastal Flood Forecasting service (a partnership between the Environment Agency, Natural Resources Wales, the Scottish Environment Protection Agency and Northern Ireland Department for Infrastructure – Rivers. It records tidal elevations at 44 locations around the UK coast. Data is made available in near real-time with measurements reported every 15 mins. The measurements provide mean sea level within each 15 min window and are reported both relative to local datum (unit m) and relative to the Ordnance Datum at Newlyn (unit mAOD).
 

--- a/source/central/fsa/alerts/index.html.md.erb
+++ b/source/central/fsa/alerts/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: Flood-monitoring API
+title: Food Alerts
 weight: 71
 ---
 
-# Food Alerts API
+# Food Alerts
 
 **API Base URL links:**
 

--- a/source/central/fsa/hygiene/index.html.md.erb
+++ b/source/central/fsa/hygiene/index.html.md.erb
@@ -3,7 +3,7 @@ title: Food Hygiene Ratings Scheme
 weight: 72
 ---
 
-# Food Hygiene Ratings Scheme
+# Food Hygiene Ratings Scheme (FHRS)
 
 **Base URL links:**
 

--- a/source/central/fsa/hygiene/index.html.md.erb
+++ b/source/central/fsa/hygiene/index.html.md.erb
@@ -1,19 +1,19 @@
 ---
-title: Food Hygiene Ratings Scheme API
+title: Food Hygiene Ratings Scheme 
 weight: 72
 ---
 
-# Food Hygiene Ratings Scheme API
+# Food Hygiene Ratings Scheme
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://api.ratings.food.gov.uk/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://api.ratings.food.gov.uk/help)
 
-**API Description:**
+**Description:**
 
 The FHRS API provides free programmatic access to the Food Standards Agency Rating Data for England, Scotland, Wales and Northern Ireland.
 

--- a/source/central/fsa/index.html.md.erb
+++ b/source/central/fsa/index.html.md.erb
@@ -3,7 +3,7 @@ title: APIs in the Food Standards Agency
 weight: 70
 ---
 
-# APIs in the Food Standards Agency
+# Food Standards Agency APIs
 
 The API catalogue contains the following Food Standards APIs:
 

--- a/source/central/gds/content/index.html.md.erb
+++ b/source/central/gds/content/index.html.md.erb
@@ -3,16 +3,16 @@ title: GOV.UK Content API
 weight: 24
 ---
 
-# GOV.UK Content API
+# GOV.UK Content
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://www.gov.uk/api/content)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://content-api.publishing.service.gov.uk)
 
- **API Description:**
+ **Description:**
 
 GOV.UK Content API makes it easy to access the data used to render content on https://www.gov.uk. For any page hosted on GOV.UK you can use the path to access the content and associated metadata for a page.

--- a/source/central/gds/datagovuk/index.html.md.erb
+++ b/source/central/gds/datagovuk/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 31
 
 # Data.gov.uk
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL production](https://data.gov.uk/api/action/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://guidance.data.gov.uk/get_data/api_documentation/)
 
-**API Description:**
+**Description:**
 
 This API allows you to access the data.gov.uk dataset metadata in a machine-readable way, as JSON.
 

--- a/source/central/gds/dcs-pilot/index.html.md.erb
+++ b/source/central/gds/dcs-pilot/index.html.md.erb
@@ -3,18 +3,18 @@ title: Document Checking Service pilot API
 weight: 29
 ---
 
-# Document Checking Service pilot API
+# Document Checking Service pilot
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL production](https://<DCS-PRODUCTION-URI>/checks/passport)
 - [Base URL testing](https://<DCS-TESTING-URI>/checks/passport)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://dcs-pilot-docs.cloudapps.digital)
 
-**API Description:**
+**Description:**
 
 The Document Checking Service (DCS) pilot is for non-public sector organisations that want to find out if British passports are valid.
 The DCS acts as an interface between a service and HM Passport Office.

--- a/source/central/gds/governments/index.html.md.erb
+++ b/source/central/gds/governments/index.html.md.erb
@@ -15,4 +15,4 @@ weight: 28
 
 **Description:**
 
-The governments API lists information about governments back to 1801
+The governments API lists information about governments back to 1801.

--- a/source/central/gds/governments/index.html.md.erb
+++ b/source/central/gds/governments/index.html.md.erb
@@ -3,16 +3,16 @@ title: GOV.UK Governments API
 weight: 28
 ---
 
-# GOV.UK Governments API
+# GOV.UK Governments
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://www.gov.uk/api/governments)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall.html)
 
-**API Description:**
+**Description:**
 
 The governments API lists information about governments back to 1801

--- a/source/central/gds/index.html.md.erb
+++ b/source/central/gds/index.html.md.erb
@@ -3,7 +3,7 @@ title: APIs in GDS
 weight: 20
 ---
 
-# APIs in the Government Digital Service
+# Government Digital Service APIs
 
 The API catalogue contains the following Government Digital Service (GDS) APIs:
 

--- a/source/central/gds/notify/index.html.md.erb
+++ b/source/central/gds/notify/index.html.md.erb
@@ -3,17 +3,17 @@ title: GOV.UK Notify API
 weight: 21
 ---
 
-# GOV.UK Notify API
+# GOV.UK Notify
 
-**API Base URL links:**
+**Base URL links:**
 
  - [Base URL](https://api.notifications.service.gov.uk)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://www.notifications.service.gov.uk/documentation)
 
-**API Description:**
+**Description:**
 
 GOV.UK Notify allows government departments to send emails, text messages and letters to their users. The API contains:
 

--- a/source/central/gds/organisations/index.html.md.erb
+++ b/source/central/gds/organisations/index.html.md.erb
@@ -3,16 +3,16 @@ title: GOV.UK Organisations API
 weight: 27
 ---
 
-# GOV.UK Organisations API
+# GOV.UK Organisations
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://www.gov.uk/api/organisations)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://github.com/alphagov/collections/blob/master/docs/api.md)
 
-**API Description:**
+**Description:**
 
-The organisations API provides information about government organisations
+The organisations API provides information about government organisations.

--- a/source/central/gds/paas/index.html.md.erb
+++ b/source/central/gds/paas/index.html.md.erb
@@ -3,9 +3,9 @@ title: GOV.UK PaaS API
 weight: 23
 ---
 
-# GOV.UK Platform as a Service (PaaS) API
+# GOV.UK Platform as a Service (PaaS) 
 
-**API Base URL links:**
+**Base URL links:**
 
 - [AWS Dublin Base URL](https://api.cloud.service.gov.uk)
 - [AWS Dublin Base URL v2](https://api.cloud.service.gov.uk/v2)
@@ -14,12 +14,12 @@ weight: 23
 - [AWS London Base URL v2](https://api.london.cloud.service.gov.uk/v2)
 - [AWS London Base URL v3](https://api.london.cloud.service.gov.uk/v3)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation for v2](https://apidocs.cloudfoundry.org/12.0.0/)
 - [Documentation for v3](http://v3-apidocs.cloudfoundry.org/version/3.74.0/)
 
-**API Description:**
+**Description:**
 
 [GOV.UK PaaS](https://www.cloud.service.gov.uk/) allows government departments to host web facing services in the AWS cloud in Dublin and London regions.
 

--- a/source/central/gds/pay/index.html.md.erb
+++ b/source/central/gds/pay/index.html.md.erb
@@ -3,17 +3,17 @@ title: GOV.UK Pay API
 weight: 22
 ---
 
-# GOV.UK Pay API
+# GOV.UK Pay 
 
-**API Base URL links:**
+**Base URL links:**
 
  - [Base URL](https://publicapi.payments.service.gov.uk)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://docs.payments.service.gov.uk/api_reference/#api-reference)
 
-**API Description:**
+**Description:**
 
 Anyone in the public sector can use GOV.UK Pay to take online payments.
 

--- a/source/central/gds/search/index.html.md.erb
+++ b/source/central/gds/search/index.html.md.erb
@@ -3,16 +3,16 @@ title: GOV.UK Search API
 weight: 26
 ---
 
-# GOV.UK Search API
+# GOV.UK Search
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://www.gov.uk/api/search.json)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://docs.publishing.service.gov.uk/apis/search/search-api.html)
 
-**API Description:**
+**Description:**
 
 GOV.UK Search API allows you to find content on GOV.UK. It's the same API that powers https://gov.uk/search/all and the other dynamic content pages on GOV.UK

--- a/source/central/gds/world-locations/index.html.md.erb
+++ b/source/central/gds/world-locations/index.html.md.erb
@@ -3,16 +3,16 @@ title: GOV.UK World locations API
 weight: 30
 ---
 
-# GOV.UK World locations API
+# GOV.UK World locations
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL production](https://www.gov.uk/api/world-locations)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall.html)
 
-**API Description:**
+**Description:**
 
 Lists world locations used on GOV.UK. This is not the same as the country register.

--- a/source/central/nhs/index.html.md.erb
+++ b/source/central/nhs/index.html.md.erb
@@ -3,9 +3,9 @@ title: APIs in NHS
 weight: 40
 ---
 
-# APIs in the National Health Service
+# NHS APIs
 
-The National Health Service (NHS) has multiple APIs that allow you to syndicate content from the NHS website.
+The NHS has multiple APIs that allow you to syndicate content from the NHS website.
 
 This includes health topics such as conditions and symptoms, and also service information such as pharmacies and hospitals.
 

--- a/source/central/ons/index.html.md.erb
+++ b/source/central/ons/index.html.md.erb
@@ -3,7 +3,7 @@ title: APIs in ONS
 weight: 30
 ---
 
-# APIs in the Office of National Statistics
+# Office for National Statistics APIs
 
 The API catalogue contains the following Office of National Statistics (ONS) APIs:
 

--- a/source/central/ons/index.html.md.erb
+++ b/source/central/ons/index.html.md.erb
@@ -5,6 +5,6 @@ weight: 30
 
 # Office for National Statistics APIs
 
-The API catalogue contains the following Office of National Statistics (ONS) APIs:
+The API catalogue contains the following Office for National Statistics (ONS) APIs:
 
 - [Statistics API](ons-stats/#ons-statistics-api)

--- a/source/central/ons/ons-stats/index.html.md.erb
+++ b/source/central/ons/ons-stats/index.html.md.erb
@@ -3,17 +3,17 @@ title: ONS Statistics API
 weight: 31
 ---
 
-# ONS: Statistics API
+# ONS: Statistics
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://api.beta.ons.gov.uk/v1)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://developer.beta.ons.gov.uk)
 
- **API Description:**
+ **Description:**
 
  The Office for National Statistics API makes datasets and other data available programmatically using HTTP. It allows you to filter datasets and directly access specific data points.
 

--- a/source/central/ons/open-geog/index.html.md.erb
+++ b/source/central/ons/open-geog/index.html.md.erb
@@ -3,16 +3,16 @@ title: Open Geography portal API
 weight: 32
 ---
 
-# ONS: Open Geography portal API
+# ONS: Open Geography portal 
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://ons-inspire.esriuk.com/arcgis/rest/services/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](https://developers.arcgis.com/rest/services-reference/get-started-with-the-services-directory.htm)
 
- **API Description:**
+ **Description:**
 
  The Open Geography portal from the Office for National Statistics (ONS) provides free and open access to the definitive source of geographic products, web applications, story maps, services and APIs. All content is available under the Open Government Licence v3.0, except where otherwise stated.

--- a/source/central/scot/index.html.md.erb
+++ b/source/central/scot/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: APIs in the Scottish Government
+title: Scottish Government APIs
 weight: 80
 ---
 
-# APIs in the Scottish Government
+# Scottish Government APIs
 
 The API catalogue contains the following Scottish Government APIs:
 

--- a/source/central/scot/stats/index.html.md.erb
+++ b/source/central/scot/stats/index.html.md.erb
@@ -3,18 +3,18 @@ title: statistics.gov.scot API
 weight: 81
 ---
 
-# statistics.gov.scot API
+# statistics.gov.scot
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://statistics.gov.scot/sparql)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [https://statistics.gov.scot/sparql?tab=api](https://statistics.gov.scot/sparql?tab=api)
 - [https://guides.statistics.gov.scot/category/37-api](https://guides.statistics.gov.scot/category/37-api)
 
-**API Description:**
+**Description:**
 
 [statistics.gov.scot](statistics.gov.scot) provides public access to the data behind Scotland's official statistics in linked open data format. 
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -3,7 +3,7 @@ title: APIs in the UK government
 weight: 10
 ---
 
-# APIs in the UK government
+# UK government APIs
 
 This API catalogue is for central government and local government APIs.
 

--- a/source/local/index.html.md.erb
+++ b/source/local/index.html.md.erb
@@ -3,7 +3,7 @@ title: APIs in local UK government
 weight: 100
 ---
 
-# APIs in local UK government
+# Local UK government APIs
 
 The API catalogue contains the following local government APIs:
 

--- a/source/local/lga/index.html.md.erb
+++ b/source/local/lga/index.html.md.erb
@@ -3,17 +3,17 @@ title: LG Inform Plus API
 weight: 102
 ---
 
-# LG Inform Plus API
+# LG Inform Plus 
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://webservices.esd.org.uk/)
 
-**API Docs URL links:**
+**Docs URL links:**
 
 - [Documentation URL](https://api.esd.org.uk/)
 
-**API Description:**
+**Description:**
 
 Access to 1 billion+ metric values for English areas drawn from approximately 50 organisations publishing metrics that describe local authorities and their component areas.
 

--- a/source/local/west-berkshire-council/index.html.md.erb
+++ b/source/local/west-berkshire-council/index.html.md.erb
@@ -3,16 +3,16 @@ title: West Berkshire Council API
 weight: 101
 ---
 
-# West Berkshire Council API
+# West Berkshire Council
 
-**API Base URL links:**
+**Base URL links:**
 
 - [Base URL](https://www.westberks.gov.uk/webservices/open311.asmx)
 
-**API Docs URL links:**
+**Docs URL links:**
 
  - [Documentation URL](http://wiki.open311.org/GeoReport_v2/)
 
- **API Description:**
+ **Description:**
 
 To raise new requests for service to West Berkshire Council for highways and countryside related issues.


### PR DESCRIPTION
## What
Removing unneeded mentions of API from the catalogue, tweaking titles to make them more active and any other small corrections.

## Why
It's an API catalogue and there is too much repetition (211 times). Headlines should be active 

## How to review
Run locally and check that the titles and headings consistently follow the format '[Organisation] APIs'
