### PR TITLE
Implement accessibility fixes

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -8,6 +8,10 @@ service_name: API Catalogue
 service_link: https://alphagov.github.io/api-catalogue
 phase: Alpha
 
+# Links to show in the footer
+footer_links:
+  Technical Documentation Accessibility: /accessibility.html
+
 # Links to show on right-hand-side of header
 header_links:
 

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,0 +1,93 @@
+---
+title: Accessibility statement for the UK Government API Catalogue
+last_reviewed_on: 2020-09-04
+review_in: 6 months
+hide_in_navigation: true
+---
+
+# Accessibility statement for the UK Government API Catalogue
+
+This accessibility statement applies to the UK Government API Catalogue at [https://alphagov.github.io/api-catalogue/#uk-government-apis](https://alphagov.github.io/api-catalogue/#uk-government-apis).
+
+This website is run by the Data Standards Authority team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without the text spilling off the screen
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+### How accessible this website is.
+
+We know some parts of this website are not fully accessible:
+
+- one page has a redundant link
+- there are issues caused by our Technical Documentation Template
+
+### Feedback and contact information
+
+If you need any part of this service in a different format like large print, audio recording or braille, email [api-standards-request@digital.cabinet-office.gov.uk](mailto:api-standards-request@digital.cabinet-office.gov.uk).
+
+We’ll consider your request and get back to you within 2 working days.
+
+### Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [api-standards-request@digital.cabinet-office.gov.uk](mailto:api-standards-request@digital.cabinet-office.gov.uk).
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+The [GOV.UK Platform as a Service (PaaS) page](https://alphagov.github.io/api-catalogue/central/gds/paas/#gov-uk-platform-as-a-service-paas) has a redundant link.
+
+Also, some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+
+We plan to fix the accessibility issues with the Technical Documentation Template by [[date]].
+
+## How we tested this website
+
+We last tested this website for accessibility issues in July 2020.
+
+We used manual and automated tests to look for issues such as:
+
+- lack of keyboard accessibility
+- link text that’s not descriptive
+- non-unique or non-hierarchical headings
+- italics, bold or block capital formatting
+- inaccessible formatting in general
+- inaccessible language
+- inaccessible diagrams or images
+- lack of colour contrast for text, important graphics and controls
+- images not having meaningful alt text
+- problems when using assistive technologies such as screen readers and screen magnifiers
+
+## What we’re doing to improve accessibility
+
+We plan to look at the redundant link by [date].
+
+We plan to fix the accessibility issues with the Technical Documentation Template by [[date]].
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 4 September 2020. It was last reviewed on 4 September 2020.
+
+This website was last tested in July 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.

--- a/source/central/ch/ch/index.html.md.erb
+++ b/source/central/ch/ch/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 51
 
 # Companies House
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://api.companieshouse.gov.uk/)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://developer.companieshouse.gov.uk/api/docs/)
 
- **Description:**
+ ## Description
 
  The Companies House API provides access to all of the public data we hold on companies free of charge. This includes information about companies, officers, people of significant control and more.

--- a/source/central/ch/streaming/index.html.md.erb
+++ b/source/central/ch/streaming/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 52
 
 # Companies House Streaming
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://stream.companieshouse.gov.uk/)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://developer-specs.companieshouse.gov.uk/streaming-api/guides/overview)
 
- **Description:**
+ ## Description
 
 The Companies House streaming API gives you access to realtime data changes of the information held at Companies House. This delivers the same information that is available through the on-demand REST API GET requests, but instead pushes data to your client as it changes, through a long-running connection that you first establish.
 

--- a/source/central/dvla/authentication/index.html.md.erb
+++ b/source/central/dvla/authentication/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 52
 
 # DVLA Authentication
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://driver-vehicle-licensing.api.gov.uk/thirdparty-access)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://developer-portal.driver-vehicle-licensing.api.gov.uk/authentication-api-description.html)
 
- **Description:**
+ ## Description
 
 The DVLA Authentication API provides authentication, change/new password and change API Key services for users of DVLA secure APIs.

--- a/source/central/dvla/index.html.md.erb
+++ b/source/central/dvla/index.html.md.erb
@@ -7,5 +7,5 @@ weight: 50
 
 The API catalogue contains the following DVLA APIs:
 
-- [DVLA Vehicle Enquiry Service](vehicle-enquiry)
-- [DVLA Authentication](authentication]
+- [DVLA Vehicle Enquiry Service](vehicle-enquiry/#dvla-vehicle-enquiry-service)
+- [DVLA Authentication](authentication/#dvla-authentication)

--- a/source/central/dvla/vehicle-enquiry/index.html.md.erb
+++ b/source/central/dvla/vehicle-enquiry/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 52
 
 # DVLA Vehicle Enquiry Service
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://driver-vehicle-licensing.api.gov.uk/vehicle-enquiry)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://developer-portal.driver-vehicle-licensing.api.gov.uk/vehicle-enquiry-service-description.html)
 
- **Description:**
+ ## Description
 
 The DVLA Vehicle Enquiry Service API provides vehicle details of a specified vehicle. It uses the vehicle registration number as input to search and provide details of the vehicle.

--- a/source/central/ea/asset/index.html.md.erb
+++ b/source/central/ea/asset/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 64
 
 # Asset Management
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://environment.data.gov.uk/asset-management/index.html)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://environment.data.gov.uk/asset-management/doc/reference)
 
-**Description:**
+## Description
 
 The Environment Agency maintains records on assets of many types related to environmental activities particularly flood defences, including some assets owned or managed by other bodies. The API provides access to these asset description records along with information on maintenance activities planned for the assets. Only some assets have an associated maintenance schedule.
 

--- a/source/central/ea/bath/index.html.md.erb
+++ b/source/central/ea/bath/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 65
 
 # Bathing Water
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL](https://environment.data.gov.uk/bwq/index.html)
 
-**Docs URL links:**
+## Docs URL links 
 
  - [Documentation URL](https://environment.data.gov.uk/bwq/doc/api-reference-v0.6.html)
 
-**Description:**
+## Description 
 
 The Environment Agency collects water quality data each year from May to September, to ensure that designated bathing water sites on the coast and inland are safe and clean for swimming and other activities. We make this data reusable and accessible to developers and to members of the public, by publishing it as linked data.
 

--- a/source/central/ea/catch/index.html.md.erb
+++ b/source/central/ea/catch/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 66
 
 # Catchment Data
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL](https://environment.data.gov.uk/catchment-planning/)
 
-**Docs URL links:**
+## Docs URL links 
 
  - [Documentation URL](https://environment.data.gov.uk/catchment-planning/ui/reference)
 
-**Description:**
+## Description 
 
 The Catchment Data Explorer (CDE) helps you explore and download information about the water environment. It supports and builds upon the data in the river basin management plans. The Catchment Data API complements this by providing selective programmatic access to the data.
 

--- a/source/central/ea/epr/index.html.md.erb
+++ b/source/central/ea/epr/index.html.md.erb
@@ -1,25 +1,25 @@
 ---
-title: Open electronic Public Register (ePR) 
+title: Open electronic Public Register (ePR)
 weight: 69
 ---
 
-# Open electronic Public Register (ePR) 
+# Open electronic Public Register (ePR)
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://environment.data.gov.uk/public-register/view/index)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://environment.data.gov.uk/public-register/view/api-reference)
 
-**Description:**
+## Description
 
 The Environment Agency licenses industry, business and individuals to carry out certain activities that have the potential to pollute the environment. When we receive an application for such a licence, we make that application and other relevant information available to the public. We do this before we make the decision of whether to issue the licence, or what conditions we will attach to it.
 
 After any permit is issued, further information is also made available on the registers. This can typically include monitoring information, details of any breaches of the terms of the licence, any enforcement actions that we have carried out and any applications to vary the terms of the licence.
 
-The open ePR (electronic Public Register) provides access to this registration and permit information both in the form of searchable web pages and as data which can be accessed by developers via an API.
+The open electronic Public Register (ePR) provides access to this registration and permit information both in the form of searchable web pages and as data which can be accessed by developers via an API.
 
 The APIs cover the following public registers:
 

--- a/source/central/ea/flood/index.html.md.erb
+++ b/source/central/ea/flood/index.html.md.erb
@@ -3,17 +3,17 @@ title: Flood-monitoring
 weight: 61
 ---
 
-# Flood-monitoring 
+# Flood-monitoring
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](http://environment.data.gov.uk/flood-monitoring)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](http://environment.data.gov.uk/flood-monitoring/doc/reference)
 
- **API Description:**
+ ## API Description
 
 The Environment Agency flood-monitoring API provides developers with access to near real-time information covering:
 
@@ -26,6 +26,6 @@ Water levels and flows are regularly monitored, usually every 15 minutes. Howeve
 
 These APIs are provided as open data under the Open Government Licence with no requirement for registration. If you make use of this data please acknowledge this with the following attribution statement:
 
-_this uses Environment Agency flood and river level data from the real-time data API (Beta)_
+"This uses Environment Agency flood and river level data from the real-time data API (Beta)."
 
 Please visit the [Defra Data Services Forum](https://support.environment.data.gov.uk/hc/en-gb) to let us know about any issues or to ask questions.

--- a/source/central/ea/hydro/index.html.md.erb
+++ b/source/central/ea/hydro/index.html.md.erb
@@ -5,19 +5,19 @@ weight: 68
 
 # Hydrology
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://environment.data.gov.uk/hydrology/landing)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://environment.data.gov.uk/hydrology/doc/reference)
 
-**Description:**
+## Description
 
 The Hydrology API provides access to historic water flow information. It complements the near real-time data provided under /flood-monitoring in that it provides access to a long term archive of quality checked and qualified data.
 
-The API and data model for the /hydrology API differs slightly from that under /flood-monitoring due to intrinsic differences (e.g. presence of quality flags on each reading for qualified data), modelling changes (e.g. adding links to [SOSA/SSN](https://www.w3.org/TR/vocab-ssn/) terms) and technology differences.
+The API and data model for the /hydrology API differs slightly from that under /flood-monitoring due to intrinsic differences (for example, presence of quality flags on each reading for qualified data), modelling changes (for example, adding links to [Semantic Sensor Network Ontology](https://www.w3.org/TR/vocab-ssn/) terms) and technology differences.
 
 In addition Environment Agency are moving to using new identifiers for monitoring stations based on GUIDs and the station URIs provided by this API use these new standards. For convenience, the stations shown here provide annotations showing the old stationReference notations (as well as the River Levels on the Internet and WISKI notations) and provide sameAs links to the equivalent /flood-monitoring stations.
 

--- a/source/central/ea/quality/index.html.md.erb
+++ b/source/central/ea/quality/index.html.md.erb
@@ -5,17 +5,21 @@ weight: 67
 
 # Water Quality
 
-**API Base URL links:**
+## API Base URL links
 
 - [Base URL](https://environment.data.gov.uk/water-quality/view/landing)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://environment.data.gov.uk/water-quality/view/doc/reference)
 
-**Description:**
+## Description
 
-The Water Quality Archive provides data on water quality measurements carried out by the Environment Agency. Samples are taken from sampling points round the country and then analysed by laboratories to measure aspects of the water quality or the environment at the sampling point. The archive provides data on these measurements and samples dating from 2000 to present day. It contains 58 million measurements on nearly 4 million samples from 58 thousand sampling points.
+The Water Quality Archive provides data on water quality measurements carried out by the Environment Agency.
+
+Samples are taken from sampling points round the country and then analysed by laboratories to measure aspects of the water quality or the environment at the sampling point.
+
+The archive provides data on these measurements and samples dating from 2000 to present day. It contains 58 million measurements on nearly 4 million samples from 58 thousand sampling points.
 
 The archive provides an API to allow selective access to the data, together with the ability to download the data split into either pre-defined or customizable subsets. The data is made available in CSV, JSON and RDF formats.
 

--- a/source/central/ea/rain/index.html.md.erb
+++ b/source/central/ea/rain/index.html.md.erb
@@ -5,17 +5,19 @@ weight: 62
 
 # Rainfall
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](http://environment.data.gov.uk/flood-monitoring)
 
-**APsI Docs URL links:**
+## APsI Docs URL links
 
  - [Documentation URL](http://environment.data.gov.uk/flood-monitoring/doc/rainfall)
 
-**API Description:**
+## API Description
 
-The Environment Agency has approximately 1000 real-time rain gauges which are connected by telemetry. Measurements of the amount of precipitation (mm) are captured in Tipping Bucket Raingauges (TBR). The data reported here gives accumulated totals for each 15 min period. The data is typically transferred once or twice per day.
+The Environment Agency has approximately 1000 real-time rain gauges which are connected by telemetry. Measurements of the amount of precipitation (mm) are captured in Tipping Bucket Raingauges (TBR).
+
+The data reported here gives accumulated totals for each 15 min period. The data is typically transferred once or twice per day.
 
 The Rainfall API provides access to these rainfall measurements, and to information on the monitoring stations providing those measurements. It is compatible with (and integrated into) the API for water level/flow readings.
 
@@ -23,6 +25,6 @@ Note that for information protection reasons the rainfall monitoring stations do
 
 These APIs are provided as open data under the Open Government Licence with no requirement for registration. If you make use of this data please acknowledge this with the following attribution statement:
 
-_this uses Environment Agency rainfall data from the real-time data API (Beta)_
+"This uses Environment Agency rainfall data from the real-time data API (Beta)."
 
 Please visit the [Defra Data Services Forum](https://support.environment.data.gov.uk/hc/en-gb) to let us know about any issues or to ask questions.

--- a/source/central/ea/tide/index.html.md.erb
+++ b/source/central/ea/tide/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 63
 
 # Tide Gauge
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](http://environment.data.gov.uk/flood-monitoring)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](http://environment.data.gov.uk/flood-monitoring/doc/tidegauge)
 
-**Description:**
+## Description
 
 The UK National Tide Gauge Network is owned and operated by the Environment Agency on behalf of the UK Coastal Flood Forecasting service (a partnership between the Environment Agency, Natural Resources Wales, the Scottish Environment Protection Agency and Northern Ireland Department for Infrastructure – Rivers. It records tidal elevations at 44 locations around the UK coast. Data is made available in near real-time with measurements reported every 15 mins. The measurements provide mean sea level within each 15 min window and are reported both relative to local datum (unit m) and relative to the Ordnance Datum at Newlyn (unit mAOD).
 
@@ -23,6 +23,6 @@ Note that all times given by the API are in GMT (also known as UTC), as indicate
 
 These APIs are provided as open data under the Open Government Licence with no requirement for registration. If you make use of this data please acknowledge this with the following attribution statement:
 
-_this uses Environment Agency tide gauge data from the real-time data API (Beta)_
+"This uses Environment Agency tide gauge data from the real-time data API (Beta)."
 
 Please visit the [Defra Data Services Forum](https://support.environment.data.gov.uk/hc/en-gb) to let us know about any issues or to ask questions.

--- a/source/central/fsa/alerts/index.html.md.erb
+++ b/source/central/fsa/alerts/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 71
 
 # Food Alerts
 
-**API Base URL links:**
+## API Base URL links 
 
 - [Base URL](https://data.food.gov.uk/food-alerts)
 
-**API Docs URL links:**
+## API Docs URL links 
 
 - [Documentation URL](https://data.food.gov.uk/food-alerts/ui/reference)
 
-**API Description:**
+## API Description 
 
 The FSA Food Alerts API provides access to current and recent Food Alerts: Allergy Alerts (AA), Product Recall Information Notices (PRIN) and Food Alerts for Action (FAFA).
 

--- a/source/central/fsa/hygiene/index.html.md.erb
+++ b/source/central/fsa/hygiene/index.html.md.erb
@@ -5,15 +5,15 @@ weight: 72
 
 # Food Hygiene Ratings Scheme (FHRS)
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL](https://api.ratings.food.gov.uk/)
 
-**Docs URL links:**
+## Docs URL links 
 
 - [Documentation URL](https://api.ratings.food.gov.uk/help)
 
-**Description:**
+## Description 
 
 The FHRS API provides free programmatic access to the Food Standards Agency Rating Data for England, Scotland, Wales and Northern Ireland.
 

--- a/source/central/gds/bank-holidays/index.html.md.erb
+++ b/source/central/gds/bank-holidays/index.html.md.erb
@@ -5,15 +5,16 @@ weight: 21
 
 # Bank Holidays
 
-**Base URL links:**
+## Base URL links
 
  - [Base URL](https://www.gov.uk/bank-holidays.json)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://github.com/alphagov/calendars/blob/master/README.md)
 
-**Description:**
+## Description
+
 The Bank Holidays API provides access to data about when bank holidays are in England and Wales, Scotland and Northern Ireland.
 
-[GOV.UK publishes information about reusing content](https://www.gov.uk/help/reuse-govuk-content)
+See the [GOV.UK guidance on reusing content](https://www.gov.uk/help/reuse-govuk-content) for more information.

--- a/source/central/gds/content/index.html.md.erb
+++ b/source/central/gds/content/index.html.md.erb
@@ -5,14 +5,16 @@ weight: 24
 
 # GOV.UK Content
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://www.gov.uk/api/content)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://content-api.publishing.service.gov.uk)
 
- **Description:**
+ ## Description
 
-GOV.UK Content API makes it easy to access the data used to render content on https://www.gov.uk. For any page hosted on GOV.UK you can use the path to access the content and associated metadata for a page.
+Use the GOV.UK Content API to access the data used to render content on https://www.gov.uk.
+
+For any page hosted on GOV.UK you can use the path to access the content and associated metadata for a page.

--- a/source/central/gds/datagovuk/index.html.md.erb
+++ b/source/central/gds/datagovuk/index.html.md.erb
@@ -5,16 +5,18 @@ weight: 31
 
 # Data.gov.uk
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL production](https://data.gov.uk/api/action/)
 
-**Docs URL links:**
+## Docs URL links
 
 - [Documentation URL](https://guidance.data.gov.uk/get_data/api_documentation/)
 
-**Description:**
+## Description
 
 This API allows you to access the data.gov.uk dataset metadata in a machine-readable way, as JSON.
 
-A dataset's metadata includes details such as title, description, usage licence, and a list of 'resources', which describe each data file that makes up the dataset. Each resource contains a format, description and URL (e.g. for download).
+A dataset's metadata includes details such as title, description, usage licence, and a list of 'resources', which describe each data file that makes up the dataset.
+
+Each resource contains a format, description and URL (for example, for download).

--- a/source/central/gds/dcs-pilot/index.html.md.erb
+++ b/source/central/gds/dcs-pilot/index.html.md.erb
@@ -5,20 +5,25 @@ weight: 29
 
 # Document Checking Service pilot
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL production](https://<DCS-PRODUCTION-URI>/checks/passport)
 - [Base URL testing](https://<DCS-TESTING-URI>/checks/passport)
 
-**Docs URL links:**
+## Docs URL links
 
 - [Documentation URL](https://dcs-pilot-docs.cloudapps.digital)
 
-**Description:**
+## Description
 
 The Document Checking Service (DCS) pilot is for non-public sector organisations that want to find out if British passports are valid.
+
 The DCS acts as an interface between a service and HM Passport Office.
+
 Your service sends a passport check request to the DCS.
+
 The DCS validates the request and sends it to HM Passport Office.
+
 HM Passport Office checks the passport data against their database and sends a response back to the DCS.
+
 The DCS sends the response to your service as outlined in check if a passport is valid.

--- a/source/central/gds/governments/index.html.md.erb
+++ b/source/central/gds/governments/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 28
 
 # GOV.UK Governments
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL](https://www.gov.uk/api/governments)
 
-**Docs URL links:**
+## Docs URL links 
 
-- [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall.html)
+- [Documentation URL](https://docs.publishing.service.gov.uk/apps/whitehall.html)
 
-**Description:**
+## Description 
 
 The governments API lists information about governments back to 1801.

--- a/source/central/gds/notify/index.html.md.erb
+++ b/source/central/gds/notify/index.html.md.erb
@@ -5,18 +5,18 @@ weight: 21
 
 # GOV.UK Notify
 
-**Base URL links:**
+## Base URL links
 
  - [Base URL](https://api.notifications.service.gov.uk)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://www.notifications.service.gov.uk/documentation)
 
-**Description:**
+## Description
 
 GOV.UK Notify allows government departments to send emails, text messages and letters to their users. The API contains:
 
 - the public-facing REST API for GOV.UK Notify, which teams can integrate with using our clients
-- an internal-only REST API built using Flask to manage services, users, templates, etc (this is what the admin app talks to)
-- asynchronous workers built using Celery to put things on queues and read them off to be processed, sent to providers, updated, etc
+- an internal-only REST API built using Flask to manage services, users, templates and more (this is what the admin app talks to)
+- asynchronous workers built using Celery to put things on queues and read them off to be processed, sent to providers, updated and more

--- a/source/central/gds/organisations/index.html.md.erb
+++ b/source/central/gds/organisations/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 27
 
 # GOV.UK Organisations
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL](https://www.gov.uk/api/organisations)
 
-**Docs URL links:**
+## Docs URL links 
 
 - [Documentation URL](https://github.com/alphagov/collections/blob/master/docs/api.md)
 
-**Description:**
+## Description 
 
 The organisations API provides information about government organisations.

--- a/source/central/gds/paas/index.html.md.erb
+++ b/source/central/gds/paas/index.html.md.erb
@@ -3,9 +3,9 @@ title: GOV.UK PaaS API
 weight: 23
 ---
 
-# GOV.UK Platform as a Service (PaaS) 
+# GOV.UK Platform as a Service (PaaS)
 
-**Base URL links:**
+## Base URL links
 
 - [AWS Dublin Base URL](https://api.cloud.service.gov.uk)
 - [AWS Dublin Base URL v2](https://api.cloud.service.gov.uk/v2)
@@ -14,12 +14,12 @@ weight: 23
 - [AWS London Base URL v2](https://api.london.cloud.service.gov.uk/v2)
 - [AWS London Base URL v3](https://api.london.cloud.service.gov.uk/v3)
 
-**Docs URL links:**
+## Docs URL links
 
 - [Documentation for v2](https://apidocs.cloudfoundry.org/12.0.0/)
 - [Documentation for v3](http://v3-apidocs.cloudfoundry.org/version/3.74.0/)
 
-**Description:**
+## Description
 
 [GOV.UK PaaS](https://www.cloud.service.gov.uk/) allows government departments to host web facing services in the AWS cloud in Dublin and London regions.
 
@@ -27,8 +27,8 @@ weight: 23
 
 There are two major versions of the API, v2 and v3.
 
-The API provides a comprehensive set of resources to manage the state of your Cloud Foundry Organisation, Spaces, Services and Applications.
+The API provides a comprehensive set of resources to manage the state of your Cloud Foundry Organisation, spaces, services and applications.
 
-[GOV.UK PaaS Technical Documentation for Users](https://docs.cloud.service.gov.uk/)
+See the [GOV.UK PaaS Technical Documentation for Users](https://docs.cloud.service.gov.uk/) for more information.
 
-The  API  handles all requests from the [Cloud Foundry Command Line Interface (CLI)](https://docs.cloudfoundry.org/cf-cli/) which is the primary user interface for users of the platform.
+The API handles all requests from the [Cloud Foundry Command Line Interface (CLI)](https://docs.cloudfoundry.org/cf-cli/) which is the primary user interface for users of the platform.

--- a/source/central/gds/pay/index.html.md.erb
+++ b/source/central/gds/pay/index.html.md.erb
@@ -3,17 +3,17 @@ title: GOV.UK Pay API
 weight: 22
 ---
 
-# GOV.UK Pay 
+# GOV.UK Pay
 
-**Base URL links:**
+## Base URL links 
 
  - [Base URL](https://publicapi.payments.service.gov.uk)
 
-**Docs URL links:**
+## Docs URL links 
 
  - [Documentation URL](https://docs.payments.service.gov.uk/api_reference/#api-reference)
 
-**Description:**
+## Description 
 
 Anyone in the public sector can use GOV.UK Pay to take online payments.
 
@@ -28,4 +28,4 @@ Then you can:
 
 GOV.UK Pay is ideal if you currently take payments using paper forms, by email or if you have an online service.
 
-More information at [https://www.payments.service.gov.uk](https://www.payments.service.gov.uk/).
+See the [GOV.UK Pay website](https://www.payments.service.gov.uk/) for more information.

--- a/source/central/gds/search/index.html.md.erb
+++ b/source/central/gds/search/index.html.md.erb
@@ -5,14 +5,16 @@ weight: 26
 
 # GOV.UK Search
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://www.gov.uk/api/search.json)
 
-**Docs URL links:**
+## Docs URL links
 
-- [Documentation URL](https://docs.publishing.service.gov.uk/apis/search/search-api.html)
+- [Documentation URL](https://docs.publishing.service.gov.uk/apps/search-api.html)
 
-**Description:**
+## Description
 
-GOV.UK Search API allows you to find content on GOV.UK. It's the same API that powers https://gov.uk/search/all and the other dynamic content pages on GOV.UK
+GOV.UK Search API allows you to find content on GOV.UK.
+
+It's the same API that powers https://gov.uk/search/all and the other dynamic content pages on GOV.UK

--- a/source/central/gds/world-locations/index.html.md.erb
+++ b/source/central/gds/world-locations/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 30
 
 # GOV.UK World locations
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL production](https://www.gov.uk/api/world-locations)
 
-**Docs URL links:**
+## Docs URL links 
 
-- [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall.html)
+- [Documentation URL](https://docs.publishing.service.gov.uk/apps/whitehall.html)
 
-**Description:**
+## Description 
 
 Lists world locations used on GOV.UK. This is not the same as the country register.

--- a/source/central/index.html.md.erb
+++ b/source/central/index.html.md.erb
@@ -13,3 +13,5 @@ The API catalogue contains APIs from the following central government department
 - [Companies House](ch/#apis-in-companies-house)
 - [Environment Agency](ea/#apis-in-the-environment-agency)
 - [Food Standards Agency](fsa/#apis-in-the-food-standards-agency)
+- [Driver and Vehicle Licensing Agency](dvla/#dvla-apis)
+- [Scottish Government](scot/#scottish-government-apis)

--- a/source/central/nhs/index.html.md.erb
+++ b/source/central/nhs/index.html.md.erb
@@ -9,5 +9,6 @@ The NHS has multiple APIs that allow you to syndicate content from the NHS websi
 
 This includes health topics such as conditions and symptoms, and also service information such as pharmacies and hospitals.
 
-- APIs: [https://developer.api.nhs.uk/nhs-api](https://developer.api.nhs.uk/nhs-api)
-- Documentation: [https://developer.api.nhs.uk/documentation](https://developer.api.nhs.uk/documentation)
+See the [NHS APIs website](https://developer.api.nhs.uk/nhs-api) page for a summary of the NHS APIs.
+
+See the [NHS API documentation](https://developer.api.nhs.uk/documentation) for information on each API.

--- a/source/central/ons/index.html.md.erb
+++ b/source/central/ons/index.html.md.erb
@@ -8,3 +8,4 @@ weight: 30
 The API catalogue contains the following Office for National Statistics (ONS) APIs:
 
 - [Statistics API](ons-stats/#ons-statistics-api)
+- [Open Geography Portal](open-geog/#ons-open-geography-portal)

--- a/source/central/ons/ons-stats/index.html.md.erb
+++ b/source/central/ons/ons-stats/index.html.md.erb
@@ -5,18 +5,18 @@ weight: 31
 
 # ONS: Statistics
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://api.beta.ons.gov.uk/v1)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://developer.beta.ons.gov.uk)
 
- **Description:**
+ ## Description
 
- The Office for National Statistics API makes datasets and other data available programmatically using HTTP. It allows you to filter datasets and directly access specific data points.
+ The Office for National Statistics (ONS) API makes datasets and other data available programmatically using HTTP. It allows you to filter datasets and directly access specific data points.
 
- The API is open and unrestricted - no API keys are required, so you can start using it immediately.
+ The API is open and unrestricted. You do not need an API key, so you can start using the API immediately.
 
  This API is currently in Beta and still being developed. Please be aware that as a result of this there may occasionally be breaking changes as we enhance functionality and respond to feedback.

--- a/source/central/ons/open-geog/index.html.md.erb
+++ b/source/central/ons/open-geog/index.html.md.erb
@@ -3,16 +3,18 @@ title: Open Geography portal API
 weight: 32
 ---
 
-# ONS: Open Geography portal 
+# ONS: Open Geography portal
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://ons-inspire.esriuk.com/arcgis/rest/services/)
 
-**Docs URL links:**
+## Docs URL links
 
  - [Documentation URL](https://developers.arcgis.com/rest/services-reference/get-started-with-the-services-directory.htm)
 
- **Description:**
+ ## Description
 
- The Open Geography portal from the Office for National Statistics (ONS) provides free and open access to the definitive source of geographic products, web applications, story maps, services and APIs. All content is available under the Open Government Licence v3.0, except where otherwise stated.
+ The Open Geography portal from the Office for National Statistics (ONS) provides free and open access to the definitive source of geographic products, web applications, story maps, services and APIs.
+
+ All content is available under the Open Government Licence v3.0, except where otherwise stated.

--- a/source/central/scot/stats/index.html.md.erb
+++ b/source/central/scot/stats/index.html.md.erb
@@ -5,18 +5,18 @@ weight: 81
 
 # statistics.gov.scot
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://statistics.gov.scot/sparql)
 
-**Docs URL links:**
+## Docs URL links
 
-- [https://statistics.gov.scot/sparql?tab=api](https://statistics.gov.scot/sparql?tab=api)
-- [https://guides.statistics.gov.scot/category/37-api](https://guides.statistics.gov.scot/category/37-api)
+- [SPARQL 1.1 Query Endpoint documentation](https://statistics.gov.scot/sparql?tab=api)
+- [Open data user guide API documentation](https://guides.statistics.gov.scot/category/37-api)
 
-**Description:**
+## Description
 
-[statistics.gov.scot](statistics.gov.scot) provides public access to the data behind Scotland's official statistics in linked open data format. 
+[statistics.gov.scot](statistics.gov.scot) provides public access to the data behind Scotland's official statistics in linked open data format.
 
 The SPARQL endpoint allows flexible querying of the datastore using the SPARQL 1.1 language.
 
@@ -26,4 +26,4 @@ The site is managed by the Scottish Government on behalf of all producers of Sco
 
 The API is provided under the Open Government Licence with no requirement for registration.
 
-For queries or comments, please contact [statistics.opendata@gov.scot](mailto:statistics.opendata@gov.scot)
+For queries or comments, please contact [statistics.opendata@gov.scot](mailto:statistics.opendata@gov.scot).

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 10
 
 This API catalogue is for central government and local government APIs.
 
-If you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/alphagov/api-catalogue/issues).
+If you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by [submitting a GitHub Issue](https://github.com/alphagov/api-catalogue/issues).
 
 Collecting a list of government APIs will help us understand:
 

--- a/source/local/London-Borough-Hackney/index.html.md.erb
+++ b/source/local/London-Borough-Hackney/index.html.md.erb
@@ -5,15 +5,23 @@ weight: 101
 
 # London Borough of Hackney: Addresses
 
-**Base URL**
-https://ndws9fa08d.execute-api.eu-west-2.amazonaws.com/production/api/v1/addresses/
+## Base URL
 
-**Documentation URL**
-[API Hub](https://developer.api.hackney.gov.uk/api/addresses_api)
-[Github](https://github.com/LBHackney-IT/HackneyAddressesAPI)
+[Base URL](https://ndws9fa08d.execute-api.eu-west-2.amazonaws.com/production/api/v1/addresses/)
 
-**Description**
+## Documentation URL
 
-We will use Addresses API when developing applications and services for the London Borough of Hackney. This ensures consistency and enables the linking of data across the organisation (via the Unique Property Reference Number). This API provides a limited interface to Hackney's Local Land and Property Gazetteer and to the National Address Gazetteer.
+- [API Hub documentation](https://developer.api.hackney.gov.uk/api/addresses_api)
+- [Github documentation](https://github.com/LBHackney-IT/HackneyAddressesAPI)
 
-We have built Developer API Hub for anyone who is interested to build, use or expand Hackney’s APIs.It serves as a central repository for all APIs built for Hackney services. The hub also mentions if a given API is compliant with [Hackney Playbook standards](https://github.com/LBHackney-IT/API-Playbook-v2-beta).
+## Description
+
+Use the Addresses API when developing applications and services for the London Borough of Hackney.
+
+This ensures consistency and enables the linking of data across the organisation through the Unique Property Reference Number.
+
+This API provides a limited interface to Hackney's Local Land and Property Gazetteer and to the National Address Gazetteer.
+
+We have built the Developer API Hub for anyone who is interested to build, use or expand Hackney’s APIs. The hub serves as a central repository for all APIs built for Hackney services.
+
+The hub also mentions if a given API is compliant with [Hackney Playbook standards](https://github.com/LBHackney-IT/API-Playbook-v2-beta).

--- a/source/local/index.html.md.erb
+++ b/source/local/index.html.md.erb
@@ -9,3 +9,4 @@ The API catalogue contains the following local government APIs:
 
 - [West Berkshire Council API](west-berkshire-council/#west-berkshire-council-api)
 - [LG Inform Plus API](lga/#lg-inform-plus-api)
+- [London Borough of Hackney](London-Borough-Hackney/#london-borough-of-hackney-addresses)

--- a/source/local/lga/index.html.md.erb
+++ b/source/local/lga/index.html.md.erb
@@ -3,18 +3,18 @@ title: LG Inform Plus API
 weight: 102
 ---
 
-# LG Inform Plus 
+# LG Inform Plus
 
-**Base URL links:**
+## Base URL links
 
 - [Base URL](https://webservices.esd.org.uk/)
 
-**Docs URL links:**
+## Docs URL links
 
 - [Documentation URL](https://api.esd.org.uk/)
 
-**Description:**
+## Description
 
 Access to 1 billion+ metric values for English areas drawn from approximately 50 organisations publishing metrics that describe local authorities and their component areas.
 
-The API also supports queries on the taxonomies and mappings published at [https://standards.esd.org.uk/](https://standards.esd.org.uk/)
+The API also supports queries on the taxonomies and mappings published at [Local Government Association esd standards website](https://standards.esd.org.uk/)

--- a/source/local/west-berkshire-council/index.html.md.erb
+++ b/source/local/west-berkshire-council/index.html.md.erb
@@ -5,14 +5,14 @@ weight: 101
 
 # West Berkshire Council
 
-**Base URL links:**
+## Base URL links 
 
 - [Base URL](https://www.westberks.gov.uk/webservices/open311.asmx)
 
-**Docs URL links:**
+## Docs URL links 
 
  - [Documentation URL](http://wiki.open311.org/GeoReport_v2/)
 
- **Description:**
+ ## Description 
 
 To raise new requests for service to West Berkshire Council for highways and countryside related issues.


### PR DESCRIPTION
Implement the following accessibility fixes to comply with the WCAG 2.1 legislation by 23 September 2020:

- make links descriptive and accessible
- make subheadings h2 instead of bold
- ensure all text is sentence case without unnecessary bold or italics
- ensure language is inclusive
- break up long paragraphs and sentences
