### PR TITLE
CSV on the Web metadata

### DIFF
--- a/data/catalogue.csv-metadata.json
+++ b/data/catalogue.csv-metadata.json
@@ -8,6 +8,7 @@
     "columns": [
       {
         "titles": "url",
+        "name": "url",
         "schema:description": "The base URL that uniquely identifies the web API",
         "propertyUrl": "schema:url",
         "datatype": "schema:URL",
@@ -15,6 +16,7 @@
       },
       {
         "titles": "name",
+        "name": "name",
         "schema:description": "The name of the web API",
         "propertyUrl": "schema:name",
         "datatype": "string",
@@ -22,6 +24,7 @@
       },
       {
         "titles": "description",
+        "name": "description",
         "schema:description": "The description of the web API",
         "propertyUrl": "schema:description",
         "datatype": "string",
@@ -29,6 +32,7 @@
       },
       {
         "titles": "documentation",
+        "name": "documentation",
         "schema:description": "The URL to the web API documentation",
         "propertyUrl": "schema:documentation",
         "datatype": "schema:URL",
@@ -36,6 +40,7 @@
       },
       {
         "titles": "license",
+        "name": "license",
         "schema:description": "The licence users of the API have to comply with",
         "propertyUrl": "schema:license",
         "datatype": "schema:URL",
@@ -43,6 +48,7 @@
       },
       {
         "titles": "maintainer",
+        "name": "maintainer",
         "schema:description": "The contact point for the web API maintainers",
         "propertyUrl": "schema:maintainer",
         "datatype": {
@@ -55,6 +61,7 @@
       },
       {
         "titles": "provider",
+        "name": "provider",
         "schema:description": "The organisation that operates the web API",
         "propertyUrl": "schema:provider",
         "datatype": {
@@ -65,6 +72,7 @@
       },
       {
         "titles": "areaServed",
+        "name": "areaServed",
         "schema:description": "The geographical coverage for the web API",
         "propertyUrl": "schema:areaServed",
         "separator": ",",
@@ -72,6 +80,7 @@
       },
       {
         "titles": "startDate",
+        "name": "startDate",
         "schema:description": "The date the web API started to operate",
         "propertyUrl": "schema:startDate",
         "datatype": "date",
@@ -79,6 +88,7 @@
       },
       {
         "titles": "endDate",
+        "name": "endDate",
         "schema:description": "The date the web API was deprecated",
         "propertyUrl": "schema:endDate",
         "datatype": "date"

--- a/data/catalogue.csv-metadata.json
+++ b/data/catalogue.csv-metadata.json
@@ -8,44 +8,89 @@
     "columns": [
       {
         "titles": "url",
-        "schema:description": "The base URL that uniquely identifies the web API"
+        "schema:description": "The base URL that uniquely identifies the web API",
+        "propertyUrl": "schema:url",
+        "datatype": "schema:URL",
+        "required": true
       },
       {
         "titles": "name",
-        "schema:description": "The name of the web API"
+        "schema:description": "The name of the web API",
+        "propertyUrl": "schema:name",
+        "datatype": "string",
+        "required": true
       },
       {
         "titles": "description",
-        "schema:description": "The description of the web API"
+        "schema:description": "The description of the web API",
+        "propertyUrl": "schema:description",
+        "datatype": "string",
+        "required": true
       },
       {
         "titles": "documentation",
-        "schema:description": "The URL to the web API documentation"
+        "schema:description": "The URL to the web API documentation",
+        "propertyUrl": "schema:documentation",
+        "datatype": "schema:URL",
+        "required": true
       },
       {
         "titles": "license",
-        "schema:description": "The licence users of the API have to comply with"
+        "schema:description": "The licence users of the API have to comply with",
+        "propertyUrl": "schema:license",
+        "datatype": "schema:URL",
+        "required": true
       },
       {
         "titles": "maintainer",
-        "schema:description": "The contact point for the web API maintainers"
+        "schema:description": "The contact point for the web API maintainers",
+        "propertyUrl": "schema:maintainer",
+        "datatype": {
+          "schema:name": "Compact Contact Point",
+          "schema:description": "A compact contact point requires a name and an email: 'Team ABC <abc-team@foo.gov.uk>'",
+          "base": "string",
+          "format": "[^\s]+\s+<[^<>\s]+>"
+        },
+        "required": true
       },
       {
         "titles": "provider",
-        "schema:description": "The organisation that operates the web API"
+        "schema:description": "The organisation that operates the web API",
+        "propertyUrl": "schema:provider",
+        "datatype": {
+          "base": "string",
+          "format": "[a-z0-9-]+"
+        },
+        "required": true
       },
       {
         "titles": "areaServed",
-        "schema:description": "The geographical coverage for the web API"
+        "schema:description": "The geographical coverage for the web API",
+        "propertyUrl": "schema:areaServed",
+        "separator": ",",
+        "datatype":  "string"
       },
       {
         "titles": "startDate",
-        "schema:description": "The date the web API started to operate"
+        "schema:description": "The date the web API started to operate",
+        "propertyUrl": "schema:startDate",
+        "datatype": "date",
+        "required": true
       },
       {
         "titles": "endDate",
-        "schema:description": "The date the web API was deprecated"
+        "schema:description": "The date the web API was deprecated",
+        "propertyUrl": "schema:endDate",
+        "datatype": "date"
       }
-    ]
+    ],
+    "primaryKey": "url",
+    "foreignKeys": [{
+      "columnReference": "provider",
+      "reference": {
+        "resource": "organisations.csv",
+        "columnReference": "identifier"
+      }
+    }]
   }
 }

--- a/data/catalogue.csv-metadata.json
+++ b/data/catalogue.csv-metadata.json
@@ -5,6 +5,14 @@
   "schema:maintainer": "API Standards team <api-standards-request@digital.cabinet-office.gov.uk>",
   "schema:description": "This API catalogue is for central government and local government APIs.\n\nIf you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/alphagov/api-catalogue/issues).\n\nCollecting a list of government APIs will help us understand:\n\n* what APIs are published\n* where API development is taking place\n* whether APIs are suitable for reuse",
   "tableSchema": {
+    "primaryKey": "url",
+    "foreignKeys": [{
+      "columnReference": "provider",
+      "reference": {
+        "resource": "organisations.csv",
+        "columnReference": "identifier"
+      }
+    }],
     "columns": [
       {
         "titles": "url",
@@ -93,14 +101,6 @@
         "propertyUrl": "schema:endDate",
         "datatype": "date"
       }
-    ],
-    "primaryKey": "url",
-    "foreignKeys": [{
-      "columnReference": "provider",
-      "reference": {
-        "resource": "organisations.csv",
-        "columnReference": "identifier"
-      }
-    }]
+    ]
   }
 }

--- a/data/catalogue.csv-metadata.json
+++ b/data/catalogue.csv-metadata.json
@@ -1,0 +1,51 @@
+{
+  "@context": "http://www.w3.org/ns/csvw",
+  "url": "catalogue.csv",
+  "schema:name": "UK government APIs",
+  "schema:maintainer": "API Standards team <api-standards-request@digital.cabinet-office.gov.uk>",
+  "schema:description": "This API catalogue is for central government and local government APIs.\n\nIf you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/alphagov/api-catalogue/issues).\n\nCollecting a list of government APIs will help us understand:\n\n* what APIs are published\n* where API development is taking place\n* whether APIs are suitable for reuse",
+  "tableSchema": {
+    "columns": [
+      {
+        "titles": "url",
+        "schema:description": "The base URL that uniquely identifies the web API"
+      },
+      {
+        "titles": "name",
+        "schema:description": "The name of the web API"
+      },
+      {
+        "titles": "description",
+        "schema:description": "The description of the web API"
+      },
+      {
+        "titles": "documentation",
+        "schema:description": "The URL to the web API documentation"
+      },
+      {
+        "titles": "license",
+        "schema:description": "The licence users of the API have to comply with"
+      },
+      {
+        "titles": "maintainer",
+        "schema:description": "The contact point for the web API maintainers"
+      },
+      {
+        "titles": "provider",
+        "schema:description": "The organisation that operates the web API"
+      },
+      {
+        "titles": "areaServed",
+        "schema:description": "The geographical coverage for the web API"
+      },
+      {
+        "titles": "startDate",
+        "schema:description": "The date the web API started to operate"
+      },
+      {
+        "titles": "endDate",
+        "schema:description": "The date the web API was deprecated"
+      }
+    ]
+  }
+}

--- a/data/operational.csv-metadata.json
+++ b/data/operational.csv-metadata.json
@@ -1,0 +1,42 @@
+{
+  "@context": "http://www.w3.org/ns/csvw",
+  "url": "operational.csv",
+  "schema:name": "Metadata for the Web APIs in the catalogue",
+  "schema:maintainer": "API Standards team <api-standards-request@digital.cabinet-office.gov.uk>",
+  "schema:description": "The metadata that allows to operate the catalogue.",
+  "tableSchema": {
+    "primaryKey": "about",
+    "foreignKeys": [{
+      "columnReference": "about",
+      "reference": {
+        "resource": "catalogue.csv",
+        "columnReference": "url"
+      }
+    }],
+    "columns": [
+      {
+        "titles": "about",
+        "name": "about",
+        "schema:description": "The Web API the record is for",
+        "propertyUrl": "schema:identifier",
+        "datatype": "schema:url",
+        "required": true
+      },
+      {
+        "titles": "dateCreated",
+        "name": "dateCreated",
+        "schema:description": "The date the Web API was added to the catalogue",
+        "propertyUrl": "schema:startDate",
+        "datatype": "date",
+        "required": true
+      },
+      {
+        "titles": "dateModified",
+        "name": "dateModified",
+        "schema:description": "The date the Web API was changed in the catalogue",
+        "propertyUrl": "schema:endDate",
+        "datatype": "date"
+      }
+    ]
+  }
+}

--- a/data/organisation.csv-metadata.json
+++ b/data/organisation.csv-metadata.json
@@ -1,0 +1,44 @@
+{
+  "@context": "http://www.w3.org/ns/csvw",
+  "url": "organisation.csv",
+  "schema:name": "UK government organisations",
+  "schema:maintainer": "API Standards team <api-standards-request@digital.cabinet-office.gov.uk>",
+  "schema:description": "The list of organisation is for internal use only. Once we have a canonical source for all organisations relevant to the API Catalogue, this list will change.",
+  "tableSchema": {
+    "primaryKey": "id",
+    "columns": [
+      {
+        "titles": "id",
+        "name": "id",
+        "schema:description": "The unique identifier for the organisation",
+        "propertyUrl": "schema:identifier",
+        "datatype": "string",
+        "required": true
+      },
+      {
+        "titles": "name",
+        "name": "name",
+        "schema:description": "The name of the organisation",
+        "propertyUrl": "schema:name",
+        "datatype": "string",
+        "required": true
+      },
+      {
+        "titles": "alternateName",
+        "name": "alternateName",
+        "schema:description": "The name or acronym the organisation is commonly referred as",
+        "propertyUrl": "alternateName",
+        "datatype": "string",
+        "required": true
+      },
+      {
+        "titles": "url",
+        "name": "url",
+        "schema:description": "The canonical URL for the organisation",
+        "propertyUrl": "url",
+        "datatype": "schema:URL",
+        "required": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds the three metadata files that describe the three sets of data that compose our initial data store:

* catalogue.csv: The set of Web API records provided by departments in government.
* organisation.csv: The set of Organisation records that we manage to classify ownership of catalogue records.
* operational.csv: The set of metadata used to operate the catalogue. 