### PR TITLE
fix link to documentation on world location and governments

### DIFF
--- a/source/central/gds/governments/index.html.md.erb
+++ b/source/central/gds/governments/index.html.md.erb
@@ -11,7 +11,7 @@ weight: 28
 
 **Docs URL links:**
 
-- [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall.html)
+- [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall/api.html)
 
 **Description:**
 

--- a/source/central/gds/world-locations/index.html.md.erb
+++ b/source/central/gds/world-locations/index.html.md.erb
@@ -11,7 +11,7 @@ weight: 30
 
 **Docs URL links:**
 
-- [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall.html)
+- [Documentation URL](https://docs.publishing.service.gov.uk/apis/whitehall/api.html)
 
 **Description:**
 


### PR DESCRIPTION
Fix the documentation link on two GDS APIs, as per issue #72 