### PR TITLE
Configure build for Github pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs', git: 'https://github.com/shippedcode/tech-docs-gem.git'
+gem 'govuk_tech_docs', git: 'https://github.com/alphagov/tech-docs-gem.git', branch: 'http-prefix-support'
 
 # For helping with deployment
 gem 'middleman-gh-pages'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs'
+gem 'govuk_tech_docs', git: 'https://github.com/shippedcode/tech-docs-gem.git'
 
 # For helping with deployment
 gem 'middleman-gh-pages'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,24 @@
+GIT
+  remote: https://github.com/shippedcode/tech-docs-gem.git
+  revision: 2d3e9d72e14d02686a4a6dc7146c6592410b7442
+  specs:
+    govuk_tech_docs (2.1.0)
+      activesupport
+      chronic (~> 0.10.2)
+      middleman (~> 4.0)
+      middleman-autoprefixer (~> 2.10.0)
+      middleman-compass (>= 4.0.0)
+      middleman-livereload
+      middleman-search-gds
+      middleman-sprockets (~> 4.0.0)
+      middleman-syntax (~> 3.2.0)
+      nokogiri
+      openapi3_parser (~> 0.5.0)
+      pry
+      redcarpet (~> 3.5.0)
+      sass
+      sprockets (~> 4.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -10,17 +31,17 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    autoprefixer-rails (6.7.7.2)
+    autoprefixer-rails (9.8.6.5)
       execjs
-    backports (3.18.1)
+    backports (3.18.2)
     chronic (0.10.2)
-    chunky_png (1.3.11)
-    coderay (1.1.2)
+    chunky_png (1.3.12)
+    coderay (1.1.3)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.20.1)
+    commonmarker (0.21.0)
       ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
@@ -38,32 +59,16 @@ GEM
     contracts (0.13.0)
     diff-lcs (1.4.4)
     dotenv (2.7.6)
-    em-websocket (0.5.1)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
-    fastimage (2.1.7)
+    fastimage (2.2.0)
     ffi (1.13.1)
-    govuk_tech_docs (2.0.7)
-      activesupport
-      chronic (~> 0.10.2)
-      middleman (~> 4.0)
-      middleman-autoprefixer (~> 2.7.0)
-      middleman-compass (>= 4.0.0)
-      middleman-livereload
-      middleman-search-gds
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.0.0)
-      nokogiri
-      openapi3_parser (~> 0.5.0)
-      pry
-      redcarpet (~> 3.3.2)
-      sass
-      sprockets (= 4.0.0.beta10)
-    haml (5.1.2)
+    haml (5.2.0)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -72,27 +77,28 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.2)
-    method_source (0.9.2)
-    middleman (4.3.7)
+    method_source (1.0.0)
+    middleman (4.3.11)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
-      kramdown (~> 1.2)
-      middleman-cli (= 4.3.7)
-      middleman-core (= 4.3.7)
-    middleman-autoprefixer (2.7.1)
-      autoprefixer-rails (>= 6.5.2, < 7.0.0)
+      kramdown (>= 2.3.0)
+      middleman-cli (= 4.3.11)
+      middleman-core (= 4.3.11)
+    middleman-autoprefixer (2.10.1)
+      autoprefixer-rails (~> 9.1)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.3.7)
+    middleman-cli (4.3.11)
       thor (>= 0.17.0, < 2.0)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.3.7)
+    middleman-core (4.3.11)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       backports (~> 3.6)
@@ -121,20 +127,20 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    middleman-search-gds (0.11.0a)
+    middleman-search-gds (0.11.1)
       execjs (~> 2.6)
       middleman-core (>= 3.2)
       nokogiri (~> 1.6)
     middleman-sprockets (4.0.0)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
-    middleman-syntax (3.0.0)
+    middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
-      rouge (~> 2.0)
+      rouge (~> 3.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
-    multi_json (1.14.1)
-    nokogiri (1.10.8)
+    multi_json (1.15.0)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     openapi3_parser (0.5.2)
       commonmarker (~> 0.17)
@@ -145,10 +151,10 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.19.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    public_suffix (4.0.5)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (4.0.6)
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
@@ -156,8 +162,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.3.4)
-    rouge (2.2.1)
+    redcarpet (3.5.0)
+    rexml (3.2.4)
+    rouge (3.23.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -171,13 +178,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    ruby-enum (0.7.2)
+    ruby-enum (0.8.0)
       i18n
     sass (3.4.25)
     sassc (2.4.0)
       ffi (~> 1.9)
     servolux (0.13.0)
-    sprockets (4.0.0.beta10)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.2)
@@ -194,7 +201,7 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel
-  govuk_tech_docs
+  govuk_tech_docs!
   middleman-gh-pages
   rspec
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/shippedcode/tech-docs-gem.git
-  revision: 2d3e9d72e14d02686a4a6dc7146c6592410b7442
+  remote: https://github.com/alphagov/tech-docs-gem.git
+  revision: 28855c05cabb311f311be8e12039151789c7dc29
+  branch: http-prefix-support
   specs:
     govuk_tech_docs (2.1.0)
       activesupport

--- a/config.rb
+++ b/config.rb
@@ -5,9 +5,15 @@ require 'lib/url_helpers'
 
 GovukTechDocs.configure(self)
 
-# use relative paths for links and sources
-activate :relative_assets
-set :relative_links, true
+# Without prefix for 'middleman serve'
+set(:govuk_assets_path, "/assets/govuk/assets/")
+
+# Add '/api-catalogue/' for 'middleman build', for Github Pages compatibility
+configure :build do
+  set(:build_dir, "build/api-catalogue")
+  set(:http_prefix, "/api-catalogue/")
+  set(:govuk_assets_path, "/api-catalogue/assets/govuk/assets/")
+end
 
 helpers UrlHelpers
 

--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -1,3 +1,0 @@
-$is-print: true;
-
-@import "govuk_tech_docs";

--- a/source/stylesheets/print.css.scss.erb
+++ b/source/stylesheets/print.css.scss.erb
@@ -1,0 +1,4 @@
+$govuk-assets-path: "<%= app.config[:govuk_assets_path] %>";
+$is-print: true;
+
+@import "govuk_tech_docs";

--- a/source/stylesheets/screen-old-ie.css.scss
+++ b/source/stylesheets/screen-old-ie.css.scss
@@ -1,4 +1,0 @@
-$is-ie: true;
-$ie-version: 8;
-
-@import "govuk_tech_docs";

--- a/source/stylesheets/screen-old-ie.css.scss.erb
+++ b/source/stylesheets/screen-old-ie.css.scss.erb
@@ -1,0 +1,5 @@
+$govuk-assets-path: "<%= app.config[:govuk_assets_path] %>";
+$is-ie: true;
+$ie-version: 8;
+
+@import "govuk_tech_docs";

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,1 +1,0 @@
-@import "govuk_tech_docs";

--- a/source/stylesheets/screen.css.scss.erb
+++ b/source/stylesheets/screen.css.scss.erb
@@ -1,0 +1,3 @@
+$govuk-assets-path: "<%= app.config[:govuk_assets_path] %>";
+
+@import "govuk_tech_docs";


### PR DESCRIPTION
Changes:

- Configure Middleman to apply a `http_prefix` of `/api-catalogue/` when building (for Github Pages compatibility)
- Use absolute links & asset paths throughout (instead of relative)
- Switch to a branch of `tech-docs-gem` which adds `http_prefix` support (fixes Search, ToC, and asset paths)

Forms part of https://github.com/alphagov/api-catalogue/issues/95