### PR TITLE
Automate publishing to Github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,37 @@
-on: [push, pull_request]
+---
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - gh-pages
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: ruby/setup-ruby@v1
-      - uses: actions/cache@v1
         with:
-          path: tmp/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - run: |
-          bundle config path tmp/bundle
-          bundle install --jobs 4 --retry 3
-      - run: bundle exec rake build
+          bundler-cache: true
+
+      - name: Test
+        run: bundle exec rspec
+
+      - name: Build
+        run: bundle exec rake build
+
+      # Checkout stripped-down gh-pages branch to a subdirectory, for publishing
+      - name: Checkout gh-pages branch
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: tmp/publish
+
+      - name: Publish
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
+          bundle exec rake publish CLONED_GH_PAGES_DIR="tmp/publish"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 Staticfile.auth
 
 spec/examples.txt
+
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 # the following line to use 'http://'
 source 'https://rubygems.org'
 
+gem 'rake'
+
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 
@@ -10,9 +12,6 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
 gem 'govuk_tech_docs', git: 'https://github.com/alphagov/tech-docs-gem.git', branch: 'http-prefix-support'
-
-# For helping with deployment
-gem 'middleman-gh-pages'
 
 # For data attributes
 gem 'activemodel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,8 +122,6 @@ GEM
       servolux
       tilt (~> 2.0.9)
       uglifier (~> 3.0)
-    middleman-gh-pages (0.4.1)
-      rake (> 0.9.3)
     middleman-livereload (3.4.6)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
@@ -203,7 +201,7 @@ PLATFORMS
 DEPENDENCIES
   activemodel
   govuk_tech_docs!
-  middleman-gh-pages
+  rake
   rspec
   tzinfo-data
   wdm (~> 0.1.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,28 @@
-require 'middleman-gh-pages'
+desc "Build site"
+task :build do
+  sh "bundle exec middleman build --clean --bail"
+end
+
+desc "Publish build to Github pages"
+task :publish do
+  require "tmpdir"
+
+  rev = `git rev-parse --short HEAD`.chomp
+
+  publish_dir = ENV.fetch("CLONED_GH_PAGES_DIR") do
+    tmp_dir = Dir.mktmpdir("publish-api-catalogue")
+    repo_url = `git config --get remote.origin.url`.chomp
+    sh("git clone --single-branch --branch gh-pages #{repo_url} #{tmp_dir}")
+    tmp_dir
+  end
+
+  sh("rsync -a --delete --exclude .git build/api-catalogue/ #{publish_dir}")
+  sh("git -C #{publish_dir} add --all")
+  sh("git -C #{publish_dir} commit -m 'Publish #{rev}'") do |ok, _|
+    if ok
+      sh("git -C #{publish_dir} push")
+    else
+      puts "Nothing to commit, skipping push"
+    end
+  end
+end


### PR DESCRIPTION
The PR updates our CI workflow to:

1. Run tests via RSpec
1. Build the site
1. Deploy to Github pages (if the branch is `master`)

In summary, whenever a pull request is merged into `master`, a new version of the site will be deployed if there are any changes.

This functionally completes #95 (although we're still using a branch of `tech-docs-gem` until upstream PRs are merged)