### PR TITLE
Add Plausible Analytics

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -5,6 +5,8 @@ require 'lib/url_helpers'
 
 GovukTechDocs.configure(self)
 
+set(:layout, :api_catalogue)
+
 # Without prefix for 'middleman serve'
 set(:govuk_assets_path, "/assets/govuk/assets/")
 

--- a/source/layouts/api_catalogue.erb
+++ b/source/layouts/api_catalogue.erb
@@ -1,0 +1,7 @@
+<% wrap_layout(:layout) do
+  content_for(:head) do
+    '<script async defer data-domain="alphagov.github.io/api-catalogue" src="https://plausible.io/js/plausible.js"></script>'
+  end
+
+  yield
+end %>


### PR DESCRIPTION
Adding to the `<head>` element because this is currently the only part of the tech-docs-gem layout which yields for extra content. There should be almost no performance impact from this `<head>` placement (vs. before `</body>`) because it uses defer/async.

References:
- https://plausible.io/