### PR TITLE
Adopt GOV.UK Ruby style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Usage: git blame --ignore-revs-file .git-blame-ignore-revs <file>
+
+# Initial Rubocop autocorrect
+c2f7f38dcde3e9d1ef6a70f6847293ba4baff390

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Test
         run: bundle exec rspec
 
+      - name: Lint
+        run: bundle exec rubocop --parallel
+
       - name: Build
         run: bundle exec rake build
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rspec.yml
+
+inherit_mode:
+  merge:
+    - Exclude

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,26 @@
 # If you do not have OpenSSL installed, change
 # the following line to use 'http://'
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rake'
+gem "rake"
 
 # For faster file watcher updates on Windows:
-gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
+gem "wdm", "~> 0.1.0", platforms: %i[mswin mingw]
 
 # Windows does not come with time zone data
-gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
+gem "tzinfo-data", platforms: %i[mswin mingw jruby]
 
 # Include the tech docs gem
-gem 'govuk_tech_docs', git: 'https://github.com/alphagov/tech-docs-gem.git', branch: 'http-prefix-support'
+gem "govuk_tech_docs", git: "https://github.com/alphagov/tech-docs-gem.git", branch: "http-prefix-support"
 
 # For data attributes
-gem 'activemodel'
+gem "activemodel"
 
 group :test do
-  gem 'rspec'
-  gem 'factory_bot'
+  gem "factory_bot"
+  gem "rspec"
 end
 
 group :development do
-  gem 'rubocop-govuk'
+  gem "rubocop-govuk"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,7 @@ group :test do
   gem 'rspec'
   gem 'factory_bot'
 end
+
+group :development do
+  gem 'rubocop-govuk'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
     autoprefixer-rails (9.8.6.5)
       execjs
     backports (3.18.2)
@@ -152,6 +153,8 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.19.2)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -159,11 +162,13 @@ GEM
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
+    rainbow (3.0.0)
     rake (13.0.0)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
+    regexp_parser (1.8.2)
     rexml (3.2.4)
     rouge (3.23.0)
     rspec (3.9.0)
@@ -179,8 +184,33 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    rubocop (0.87.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.1.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.7.1)
+      parser (>= 2.7.1.5)
+    rubocop-govuk (3.17.0)
+      rubocop (= 0.87.1)
+      rubocop-rails (= 2.6.0)
+      rubocop-rake (= 0.5.1)
+      rubocop-rspec (= 1.42.0)
+    rubocop-rails (2.6.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.82.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (1.42.0)
+      rubocop (>= 0.87.0)
     ruby-enum (0.8.0)
       i18n
+    ruby-progressbar (1.10.1)
     sass (3.4.25)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -196,6 +226,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -206,6 +237,7 @@ DEPENDENCIES
   govuk_tech_docs!
   rake
   rspec
+  rubocop-govuk
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,11 @@
+require "rspec/core/rake_task"
+require "rubocop/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
+
+task default: ["spec", "rubocop:auto_correct"]
+
 desc "Build site"
 task :build do
   sh "bundle exec middleman build --clean --bail"

--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,7 @@
-require 'govuk_tech_docs'
-require 'lib/api_catalogue'
-require 'lib/dashboard_stats'
-require 'lib/url_helpers'
+require "govuk_tech_docs"
+require "lib/api_catalogue"
+require "lib/dashboard_stats"
+require "lib/url_helpers"
 
 GovukTechDocs.configure(self)
 

--- a/lib/api_catalogue.rb
+++ b/lib/api_catalogue.rb
@@ -4,7 +4,7 @@ require_relative "organisation"
 
 class ApiCatalogue
   def self.from_csv(csv_path)
-    header_converter = lambda { |header| header.underscore.to_sym }
+    header_converter = ->(header) { header.underscore.to_sym }
 
     apis = CSV
       .foreach(csv_path, headers: true, header_converters: [header_converter])
@@ -19,15 +19,15 @@ class ApiCatalogue
     @organisations_apis = group_by_organisation(apis)
   end
 
-  private
+private
 
   def group_by_organisation(apis)
     apis
       .sort_by(&:organisation)
       .group_by(&:organisation)
-      .each_with_object({}) do |(organisation, apis), result|
-        organisation = Organisation.new(name: organisation, alternate_name: apis.first&.provider)
-        result[organisation] = apis.sort_by(&:name)
+      .each_with_object({}) do |(organisation, org_apis), result|
+        organisation = Organisation.new(name: organisation, alternate_name: org_apis.first&.provider)
+        result[organisation] = org_apis.sort_by(&:name)
       end
   end
 end

--- a/lib/dashboard_stats.rb
+++ b/lib/dashboard_stats.rb
@@ -22,10 +22,10 @@ class DashboardStats
   end
 
   def by_organisation
-    @_by_organsation ||= calculate_stats_by_organisation
+    @by_organisation ||= calculate_stats_by_organisation
   end
 
-  private
+private
 
   attr_reader :api_catalogue
 

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -1,11 +1,11 @@
 module UrlHelpers
+module_function
+
   def organisation_path(organisation)
     "/#{organisation.slug}/index.html"
   end
-  module_function :organisation_path
 
   def api_path(organisation:, api:)
     "/#{organisation.slug}/#{api.slug}/index.html"
   end
-  module_function :api_path
 end

--- a/spec/lib/api_catalogue_spec.rb
+++ b/spec/lib/api_catalogue_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ApiCatalogue do
       first_org, first_org_apis = api_catalogue.organisations_apis.first
 
       expect(first_org.name).to eq "A"
-      expect(first_org_apis.map(&:name)).to eq ["A1", "A2"]
+      expect(first_org_apis.map(&:name)).to eq %w[A1 A2]
     end
   end
 end

--- a/spec/lib/dashboard_stats_spec.rb
+++ b/spec/lib/dashboard_stats_spec.rb
@@ -2,21 +2,21 @@ require "api_catalogue"
 require "dashboard_stats"
 
 RSpec.describe DashboardStats do
+  subject(:stats) { described_class.new(api_catalogue) }
+
   let(:csv_path) { File.expand_path("../../data/inputs/apic.csv", __dir__) }
   let(:api_catalogue) { ApiCatalogue.from_csv(csv_path) }
 
-  subject { described_class.new(api_catalogue) }
-
   describe "#total_apis" do
     it "sums the APIs across each organisation" do
-      expect(subject.total_apis).to be > 100
+      expect(stats.total_apis).to be > 100
     end
   end
 
   describe "#total_organisations" do
     it "sums the number of organisations" do
-      expect(subject.total_organisations).to be > 10
-      expect(subject.total_organisations).to be < subject.total_apis
+      expect(stats.total_organisations).to be > 10
+      expect(stats.total_organisations).to be < stats.total_apis
     end
   end
 
@@ -33,14 +33,14 @@ RSpec.describe DashboardStats do
     let(:api_catalogue) { ApiCatalogue.new(apis) }
 
     it "matches the most recently updated API, across all organisations" do
-      expect(subject.last_updated).to eq Date.new(2020, 1, 1)
+      expect(stats.last_updated).to eq Date.new(2020, 1, 1)
     end
   end
 
   describe "#by_organisation" do
     it "provides stats per organisation" do
-      nhs_stats = subject.by_organisation.detect do |stats|
-        stats.organisation.name.casecmp?("National Health Service")
+      nhs_stats = stats.by_organisation.detect do |org_stats|
+        org_stats.organisation.name.casecmp?("National Health Service")
       end
 
       expect(nhs_stats).to have_attributes(
@@ -52,7 +52,7 @@ RSpec.describe DashboardStats do
     end
 
     it "orders the organisations by number of APIs" do
-      subject.by_organisation.each_cons(2) do |org1, org2|
+      stats.by_organisation.each_cons(2) do |org1, org2|
         expect(org1.api_count).to be >= org2.api_count
       end
     end


### PR DESCRIPTION
This PR adopts the [GOV.UK code formatting rules for Ruby](https://gds-way.cloudapps.digital/manuals/programming-languages/ruby.html#code-formatting).

Changes:

- Adds Rubocop (a Ruby code linter) configured with the [GOV.UK Rubocop rules](https://github.com/alphagov/rubocop-govuk)
- Corrects existing code to match the rules
- Adds a linting step to our GitHub Actions workflow, to ensure each PR keeps to the rules
- Configure the default Rake task to run specs (with RSpec) and lint (with Rubocop)