### PR TITLE
Render markdown + unescape newlines in API descriptions

### DIFF
--- a/helpers/format_helpers.rb
+++ b/helpers/format_helpers.rb
@@ -1,0 +1,13 @@
+require "redcarpet"
+
+module FormatHelpers
+  def render_markdown(content)
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true)
+      .render(content)
+  end
+
+  # Converts escaped newlines into literal newlines ("\\n" => "\n")
+  def unescape_newlines(content)
+    content.gsub('\n', "\n")
+  end
+end

--- a/source/api_details.html.erb
+++ b/source/api_details.html.erb
@@ -23,7 +23,7 @@
 
 <% if api.description.present? %>
   <h2>Description:</h2>
-  <%= escape_html(api.description) %>
+  <%= render_markdown(unescape_newlines(api.description)) %>
 <% end %>
 
 <% if api.license.present? %>

--- a/spec/helpers/format_helpers_spec.rb
+++ b/spec/helpers/format_helpers_spec.rb
@@ -1,0 +1,35 @@
+require_relative "../../helpers/format_helpers"
+
+RSpec.describe FormatHelpers do
+  subject(:helpers) do
+    Class.new { include FormatHelpers }.new
+  end
+
+  describe "#render_markdown" do
+    it "renders HTML from the markdown content" do
+      markdown = "Some content"
+
+      expect(helpers.render_markdown(markdown)).to match "<p>Some content</p>"
+    end
+
+    it "autolinks any URLs which aren't normal markdown links" do
+      markdown = "Checkout https://example.com"
+
+      expect(helpers.render_markdown(markdown))
+        .to match '<p>Checkout <a href="https://example.com">https://example.com</a></p>'
+    end
+  end
+
+  describe "#unescape_newlines" do
+    it "converts escaped newlines into unescaped, literal newlines" do
+      original = 'foo\nbar\n\nbaz\n'
+
+      expect(helpers.unescape_newlines(original)).to eq <<~TXT
+        foo
+        bar
+
+        baz
+      TXT
+    end
+  end
+end


### PR DESCRIPTION
This PR renders any markdown in the API descriptions, and converts any escaped newlines into actual newline characters before conversion (so two consecutive newlines will result in a new paragraph, as per standard Markdown formatting).

Part of https://github.com/alphagov/api-catalogue/issues/89

This PR does **not** address data issues where newlines are encoded incorrectly (we've seen `-n` and `/n`). I'll make a follow-up PR to clean the data itself rather than handle this in code.

## Examples:  GOV.UK PaaS

### Before

<img width="1031" alt="gov-uk-paas-before" src="https://user-images.githubusercontent.com/4125410/96253877-474dba80-0fac-11eb-8c42-d09be840b1e6.png">

### After

<img width="1031" alt="gov-uk-paas-after" src="https://user-images.githubusercontent.com/4125410/96253903-52a0e600-0fac-11eb-8845-fb91a5e155b8.png">

## Examples: FHRS

### Before

<img width="1031" alt="fhrs-before" src="https://user-images.githubusercontent.com/4125410/96253947-60ef0200-0fac-11eb-99ae-fc30a8fcd116.png">

### After

<img width="1143" alt="fhrs-after" src="https://user-images.githubusercontent.com/4125410/96253967-6b110080-0fac-11eb-8d90-e72def5a9548.png">