### PR TITLE
Adjust config for new domain

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :publish do
     tmp_dir
   end
 
-  sh("rsync -a --delete --exclude .git build/api-catalogue/ #{publish_dir}")
+  sh("rsync -a --delete --exclude .git build/ #{publish_dir}")
   sh("git -C #{publish_dir} add --all")
   sh("git -C #{publish_dir} commit -m 'Publish #{rev}'") do |ok, _|
     if ok

--- a/config.rb
+++ b/config.rb
@@ -7,16 +7,6 @@ GovukTechDocs.configure(self)
 
 set(:layout, :api_catalogue)
 
-# Without prefix for 'middleman serve'
-set(:govuk_assets_path, "/assets/govuk/assets/")
-
-# Add '/api-catalogue/' for 'middleman build', for Github Pages compatibility
-configure :build do
-  set(:build_dir, "build/api-catalogue")
-  set(:http_prefix, "/api-catalogue/")
-  set(:govuk_assets_path, "/api-catalogue/assets/govuk/assets/")
-end
-
 helpers UrlHelpers
 
 csv_path = File.expand_path("data/inputs/apic.csv", __dir__)

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,11 +1,10 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: https://alphagov.github.io/api-catalogue
-http_prefix: /api-catalogue
+host: https://www.api.gov.uk
 
 # Header-related options
 show_govuk_logo: false
 service_name: API Catalogue
-service_link: https://alphagov.github.io/api-catalogue
+service_link: https://www.api.gov.uk
 phase: Alpha
 
 # Links to show in the footer

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -7,7 +7,7 @@ hide_in_navigation: true
 
 # Accessibility statement for the UK Government API Catalogue
 
-This accessibility statement applies to the UK Government API Catalogue at [https://alphagov.github.io/api-catalogue/#uk-government-apis](https://alphagov.github.io/api-catalogue/#uk-government-apis).
+This accessibility statement applies to the UK Government API Catalogue at [https://www.api.gov.uk/#uk-government-apis](https://www.api.gov.uk/#uk-government-apis).
 
 This website is run by the Data Standards Authority team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
@@ -57,7 +57,7 @@ The content listed below is non-accessible for the following reasons.
 
 #### Non-compliance with the accessibility regulations
 
-The [GOV.UK Platform as a Service (PaaS) page](https://alphagov.github.io/api-catalogue/central/gds/paas/#gov-uk-platform-as-a-service-paas) has a redundant link. This is not a fail, but should be changed under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+The [GOV.UK Platform as a Service (PaaS) page](https://www.api.gov.uk/central/gds/paas/#gov-uk-platform-as-a-service-paas) has a redundant link. This is not a fail, but should be changed under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
 
 Also, some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 

--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -1,0 +1,3 @@
+$is-print: true;
+
+@import "govuk_tech_docs";

--- a/source/stylesheets/print.css.scss.erb
+++ b/source/stylesheets/print.css.scss.erb
@@ -1,4 +1,0 @@
-$govuk-assets-path: "<%= app.config[:govuk_assets_path] %>";
-$is-print: true;
-
-@import "govuk_tech_docs";

--- a/source/stylesheets/screen-old-ie.css.scss
+++ b/source/stylesheets/screen-old-ie.css.scss
@@ -1,0 +1,4 @@
+$is-ie: true;
+$ie-version: 8;
+
+@import "govuk_tech_docs";

--- a/source/stylesheets/screen-old-ie.css.scss.erb
+++ b/source/stylesheets/screen-old-ie.css.scss.erb
@@ -1,5 +1,0 @@
-$govuk-assets-path: "<%= app.config[:govuk_assets_path] %>";
-$is-ie: true;
-$ie-version: 8;
-
-@import "govuk_tech_docs";

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -1,0 +1,1 @@
+@import "govuk_tech_docs";

--- a/source/stylesheets/screen.css.scss.erb
+++ b/source/stylesheets/screen.css.scss.erb
@@ -1,3 +1,0 @@
-$govuk-assets-path: "<%= app.config[:govuk_assets_path] %>";
-
-@import "govuk_tech_docs";


### PR DESCRIPTION
Config changes for https://github.com/alphagov/api-catalogue/issues/111 - moving from the Github pages URL (https://alphagov.github.io/api-catalogue) to a custom domain (https://www.api.gov.uk)

Summary:

- Remove `http_prefix` related settings required for serving site of GH pages default domain
- Undo customisation of GOV.UK frontend assets path required for GH pages default domain
- Update references to outgoing URL