### PR TITLE
Ensure CNAME config is kept on gh-pages branch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :publish do
     tmp_dir
   end
 
-  sh("rsync -a --delete --exclude .git build/ #{publish_dir}")
+  sh("rsync -a --delete --exclude .git --exclude CNAME build/ #{publish_dir}")
   sh("git -C #{publish_dir} add --all")
   sh("git -C #{publish_dir} commit -m 'Publish #{rev}'") do |ok, _|
     if ok


### PR DESCRIPTION
This is small config change to ensure the `CNAME` file on the `gh-pages` branch doesn't get removed by the `publish` Rake task (currently this issue results in the custom domain setting being removed as we publish, which is a bug).