### PR TITLE
Add ADR for Removal of the TDG

### DIFF
--- a/adr/0001-remove-tech-docs-gem-dependency.md
+++ b/adr/0001-remove-tech-docs-gem-dependency.md
@@ -1,0 +1,46 @@
+---
+creation_date: 2020-11-05
+decision_date: null
+status: proposed
+---
+
+# Remove the Tech Docs Gem Dependency
+
+## Context
+
+The main data source of the API catalogue website was originally a collection of
+markdown files. The build process uses the Middleman static site generator
+configured by the [Tech Docs Gem](https://github.com/alphagov/tech-docs-gem)
+('TDG').
+
+The TDG provides additional functionality including search, sidebar
+navigation ('Table of Contents'), the layout, and styling.
+
+The TDG is not necessarily a good fit for the API catalogue because the project
+isn't purely documentation, and our data source is now a CSV.
+
+In particular it is difficult to override templates inherited from the gem, to
+adjust the layout on a particular page or add page-specific JavaScript for
+example.
+
+Using TDG to render the Table of Contents is slow for our site because
+by design every page is re-rendered multiple times to pull out the headings
+(adding over a minute to build times).
+
+The TDG also requires specific dependency versions. These version
+restrictions prevent us being in control of version upgrades which are necessary
+to remain on support versions and receive security patches.
+
+## Decision
+
+Remove the TDG as a dependency by vendoring the code relevant to
+the API catalogue directly into the project itself.
+
+## Consequences
+
+The API catalogue project can be customized more easily, and the team has more
+control over dependency management.
+
+Downsides include the API catalogue having more code which needs to be
+maintained. Also we no longer automatically benefit from any future fixes or
+additional features added to the TDG without manually copying them across.

--- a/adr/0001-remove-tech-docs-gem-dependency.md
+++ b/adr/0001-remove-tech-docs-gem-dependency.md
@@ -1,7 +1,7 @@
 ---
 creation_date: 2020-11-05
 decision_date: null
-status: proposed
+status: approved
 ---
 
 # Remove the Tech Docs Gem Dependency

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,19 @@
+---
+creation_date: 1970-01-01
+decision_date: null
+status: proposed|accepted|rejected|deprecated|superseded
+---
+
+# Title
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
Template is based off the Architecture decision record template by Michael Nygard:

https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md

Except the status (& dates) are stored in front-matter for easy programmatic access in the future (Github renders these as a table by default).