### PR TITLE
Upgrade jquery from 1.12.4 to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,9 +1032,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "govuk-frontend": "^3.6.0",
-    "jquery": "^1.12.4",
+    "jquery": "^3",
     "lodash": "^4.17.20",
     "mark.js": "^8.11.1",
     "tablesort": "^5.2.1"


### PR DESCRIPTION
Resolves 3 NPM audit issues:

- https://npmjs.com/advisories/328
- https://npmjs.com/advisories/796
- https://npmjs.com/advisories/1518

Ran migration plugins noted here, no changes were proposed:
https://jquery.com/upgrade-guide/3.0/#jquery-migrate-plugin

---

Upgrading major versions of jQuery doesn't reveal any incompatibilities with our JavaScript, or other 3rd party libraries, but it does change the supported browsers. From the upgrade guide:

> # Browser Support
> As of jQuery 3.0, the following browsers are supported:
> -  Internet Explorer: 9+
>  - Chrome, Edge, Firefox, Safari: Current and Current - 1
> - Opera: Current
> - Safari Mobile iOS: 7+
> - Android 4.0+

Whereas version `1.x` supported IE 6, 7, 8.

I think it's worth upgrading to keep on a version with security updates, but it may degrade JS functionality (like search) on older browsers (we could verify this in a virtual machine). Normal navigation of the site will work regardless.