### PR TITLE
Fix style and accessibility issues

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -9,7 +9,7 @@ phase: Alpha
 
 # Links to show in the footer
 footer_links:
-  Technical Documentation Accessibility: /accessibility.html
+  Accessibility: /accessibility.html
 
 # Links to show on right-hand-side of header
 header_links:

--- a/source/api_details.html.erb
+++ b/source/api_details.html.erb
@@ -1,55 +1,57 @@
 <h1 id="<%= api.name.parameterize %>"><%= api.name %></h1>
 
 <% if api.url.present? %>
-  <h2>Endpoint URL:</h2>
-  <ul>
-    <li><%= link_to(api.url, api.url) %></li>
-  </ul>
+  <h2>Endpoint</h2>
+  <p>
+    <code>
+      <%= api.url %>
+    </code>
+  </p>
 <% end %>
 
 <% if api.documentation.present? %>
-  <h2>Documentation URL:</h2>
-  <ul>
-    <li><%= link_to(api.documentation, api.documentation) %></li>
-  </ul>
+  <h2>Documentation</h2>
+  <p>
+    <%= link_to(api.name + " documentation", api.documentation) %>
+  </p>
 <% end %>
 
 <% if api.maintainer.present? %>
-  <h2>Contact:</h2>
-  <ul>
-    <li><%= escape_html(api.maintainer) %></li>
-  </ul>
+  <h2>Contact</h2>
+  <p>
+    <%= escape_html(api.maintainer) %>
+  </p>
 <% end %>
 
 <% if api.description.present? %>
-  <h2>Description:</h2>
+  <h2>Description</h2>
   <%= render_markdown(unescape_newlines(api.description)) %>
 <% end %>
 
 <% if api.license.present? %>
-  <h2>License:</h2>
-  <ul>
-    <li><%= escape_html(api.license) %></li>
-  </ul>
+  <h2>Licence</h2>
+  <p>
+    <%= escape_html(api.license) %>
+  </p>
 <% end %>
 
 <% if api.area_served.present? %>
-  <h2>Geographic Area:</h2>
-  <ul>
-    <li><%= escape_html(api.area_served) %></li>
-  </ul>
+  <h2>Geographic area</h2>
+  <p>
+    <%= escape_html(api.area_served) %>
+  </p>
 <% end %>
 
 <% if api.start_date.present? %>
-  <h2>Start Date:</h2>
-  <ul>
-    <li><%= api.start_date.to_formatted_s(:iso8601) %></li>
-  </ul>
+  <h2>Start date</h2>
+  <p>
+    <%= api.start_date.to_formatted_s(:rfc822) %>
+  </p>
 <% end %>
 
 <% if api.end_date.present? %>
-  <h2>Expiry Date:</h2>
-  <ul>
-    <li><%= api.end_date.to_formatted_s(:iso8601) %></li>
-  </ul>
+  <h2>Expiry date</h2>
+  <p>
+    <%= api.end_date.to_formatted_s(:rfc822) %>
+  </p>
 <% end %>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,13 +1,13 @@
 ---
-title: UK Government APIs
+title: UK government APIs
 weight: 1
 ---
 
-# UK Government APIs
+# UK government APIs
 
 This API catalogue is for central and local government APIs.
 
-If you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/alphagov/api-catalogue/issues).
+If you're working on an API that publishes open data or connects government with users from other organisations or wider industry, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by [creating an issue in the API Catalogue GitHub repo](https://github.com/alphagov/api-catalogue/issues).
 
 Collecting a list of government APIs helps us understand:
 
@@ -15,14 +15,14 @@ Collecting a list of government APIs helps us understand:
 * where API development is taking place
 * whether APIs are suitable for reuse
 
-and helps users across government find and access inter-departmental data exchanges, as well as sharing best practice in API development.
+The API catalogue also helps users across government find and access inter-departmental data exchanges, as well as sharing best practice in API development.
 
-*Please note that all of the APIs and data sources recorded in the Catalogue have their own licensing and access restrictions, check the documentation for each individual API for more details.*
+All of the APIs and data sources published in the catalogue have their own licensing and access restrictions. Check the documentation for each individual API for more details.
 
-# Getting in touch
+## Get in touch
 
-The API Catalogue is a central part of the [Data Standards Authority's](https://www.gov.uk/government/groups/data-standards-authority) API Programme, which aims to improve how APIs are produced, managed and used across government. For more information, or to ask to be added to the Government API & Data Exchange community, please contact: <api-programme@digital.cabinet-office.gov.uk>.
+The API Catalogue is a central part of the [Data Standards Authority's](https://www.gov.uk/government/groups/data-standards-authority) API programme, which aims to improve how APIs are produced, managed and used across government. For more information, or to ask to be added to the government API & Data Exchange community, email <api-programme@digital.cabinet-office.gov.uk>.
 
-If you have any questions about the catalogue, or how to add your APIs to it, please contact: <api-catalogue@digital.cabinet-office.gov.uk>.
+If you have any questions about the catalogue, or how to add your APIs to it, email <api-catalogue@digital.cabinet-office.gov.uk>.
 
-If you are looking to set up an api.gov.uk domain for your API, please contact: <api-domain-request@digital.cabinet-office.gov.uk>.
+If you are looking to set up an api.gov.uk domain for your API, email <api-domain-request@digital.cabinet-office.gov.uk>.

--- a/source/overview_index.html.erb
+++ b/source/overview_index.html.erb
@@ -3,14 +3,14 @@ title: Index
 weight: 2
 ---
 
-<h1 id="index">Index</h1>
+<h1 id="index">A to Z</h1>
 
 <table class="js-table-sort">
   <thead>
     <tr>
       <th class="govuk-!-width-one-third" data-sort-default>Name</th>
       <th class="govuk-!-width-one-third">Department</th>
-      <th class="govuk-!-width-one-third">License</th>
+      <th class="govuk-!-width-one-third">Licence</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
This PR fixes some style and accessibility issues in the static and auto-generated content.

I've:

- removed italics
- fixed sentences that follow on from bullets
- removed bullets where there’s no list (only one item)
- changed capital ‘C’ to lowercase where it’s “the catalogue” rather than “the API Catalogue”
- removed ‘please’
- fixed inaccessible links
- removed colons from headings
- renamed ‘Index’ to ‘A to Z’, because ‘index’ is a concept from print. We use ‘A to Z’ elsewhere, eg the GOV.UK style guide
- on the API details page, corrected endpoints so they’re in code format and without a link, and changed date formatting so dates are closer to GOV.UK style
- corrected the description of the accessibility link
- fixed typos, grammar errors and some style issues

Happy to chat about any of the suggestions!
