### PR TITLE
Fix A to Z title so it matches page title

### DIFF
--- a/source/overview_index.html.erb
+++ b/source/overview_index.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Index
+title: A to Z
 weight: 2
 ---
 


### PR DESCRIPTION
Following the changes in https://github.com/alphagov/api-catalogue/pull/218, this fixes the nav name for the 'A to Z' page so it matches the new page title.