### PR TITLE
Add archive for interesting resources and links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: bundle exec rubocop --parallel
 
+      - name: Validate schema
+        run: bundle exec rake schema
+
       - name: Build
         run: bundle exec rake build
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,5 @@ gem "middleman-sprockets"
 gem "redcarpet"
 gem "sass"
 gem "sprockets"
+
+gem "builder", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
     backports (3.21.0)
+    builder (3.2.4)
     chunky_png (1.4.0)
     coderay (1.1.3)
     coffee-script (2.4.1)
@@ -211,6 +212,7 @@ PLATFORMS
 DEPENDENCIES
   activemodel
   activesupport
+  builder (~> 3.0)
   factory_bot
   middleman (~> 4.0)
   middleman-autoprefixer

--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,7 @@ require "lib/api_catalogue_overview"
 require "lib/api_catalogue"
 require "lib/dashboard_stats"
 require "lib/url_helpers"
+require "lib/links"
 
 ### Config from tech-docs-gem: start ###
 require "middleman"
@@ -69,6 +70,11 @@ helpers do
       ("/#{current_page.path}") == page_path,
       !current_page.data.parent.nil? && current_page.data.parent.to_s == page_path,
     ].any?
+  end
+
+  def links
+    links_csv = File.expand_path("data/links.csv", __dir__)
+    Links.from_csv(links_csv)
   end
 end
 

--- a/data/links.csv
+++ b/data/links.csv
@@ -1,0 +1,1 @@
+dateAdded,url,title

--- a/data/links.csv
+++ b/data/links.csv
@@ -1,1 +1,193 @@
 dateAdded,url,title
+2021-01-15,https://matthewreinbold.com/2021/01/08/WhyAISuccessIsAPIBuilt/,Why AI Success is API Built
+2021-01-15,https://opensource.googleblog.com/2021/01/the-api-registry-api.html,The API Registry API | Google Open Source Blog
+2021-01-15,https://tyk.io/3-ways-to-try-out-your-api-design-before-you-build/,3 ways to try out your API design before you build - Tyk API Gateway and API Management
+2021-01-18,https://www.theregister.com/2021/01/15/20_years_of_drupal/,"20 years of Drupal: Founder Dries Buytaert on API first, the end of breaking compatibility, and JavaScript bloat"
+2021-01-22,https://nordicapis.com/4-ways-your-api-specification-can-fall-short-and-what-to-do-about-it/,4 Ways Your API Specification Can Fall Short (And What to Do About It) | Nordic APIs
+2021-01-22,https://twitter.com/dancohen/status/1350831682350415872,Never Been Seen | Science Museum Group Collection
+2021-01-22,https://www.howtographql.com/,How to GraphQL - The Fullstack Tutorial for GraphQL
+2021-02-05,https://apievangelist.com/2021/01/30/making-sense-of-the-different-types-of-api-testing/,Making Sense of the Different Types of API Testing
+2021-02-05,https://apifriends.com/news/api-news-roundup-january-2021/,API News Roundup – January 2021
+2021-02-05,https://www.radware.com/newsevents/pressreleases/2021/api-abuse-threat-bot-traffic,ShieldSquare Captcha
+2021-02-12,https://cloud.google.com/blog/products/api-management/top-5-trends-for-api-powered-digital-transformation-in-2021,Google Cloud State of APIs Report - Digital Transformation | Google Cloud Blog
+2021-02-12,https://nordicapis.com/generating-web-api-tests-from-an-openapi-specification/,Generating Web API Tests From an OpenAPI Specification | Nordic APIs
+2021-02-12,https://www.apiscene.io/graphql/graphql-apis-avoiding-security-pitfalls/,GraphQL APIs :Avoiding Security Pitfalls - APIscene
+2021-02-12,https://www.forbes.com/sites/adrianbridgwater/2021/01/11/where-its-at-geospatial-commission-charts-api-route-to-map-data-sharing/,"Where It's At, Geospatial Commission Charts API Route To Map Data Sharing"
+2021-02-19,https://joemorrison.medium.com/openstreetmap-is-having-a-moment-dcc7eef1bb01,OpenStreetMap is Having a Moment. The Billion Dollar Dataset Next Door
+2021-02-19,https://searchapparchitecture.techtarget.com/tip/10-API-security-guidelines-and-best-practices,10 API security guidelines and best practices
+2021-02-19,https://www.brighttalk.com/webcast/17994/464062,Best Practices for Modern API Testing
+2021-02-19,https://www.youtube.com/watch?v=xZQNZhRcCXw,REST vs. GraphQL: Making the Right Choice
+2021-02-26,https://blog.postman.com/how-to-set-up-public-workspaces/,How to Set Up Your First Public Workspace in 5 Steps | Postman Blog
+2021-02-26,https://blog.postman.com/postman-api-hackathon-winners/,"Announcing the $100,000 Postman API Hack Winners | Postman Blog"
+2021-02-26,https://medium.com/swlh/building-systems-with-static-apis-631c165d3882,Building Systems With Static APIs | The Startup
+2021-02-26,https://netflixtechblog.com/beyond-rest-1b76f7c20ef6,Beyond REST: Rapid Development With GraphQL Microservices | Netflix TechBlog
+2021-02-26,https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0,Migrating from OpenAPI 3.0 to 3.1.0 - OpenAPI Initiative
+2021-03-05,http://apistylebook.com/,API Stylebook
+2021-03-05,https://medium.com/event-driven-utopia/understanding-asyncapis-with-a-practical-example-ee2b4be221d8,Understanding AsyncAPIs with a Practical Example
+2021-03-05,https://nordicapis.com/top-expectations-for-api-products-in-2021/,Top Expectations for API Products in 2021 | Nordic APIs
+2021-03-05,https://towardsdatascience.com/the-design-of-an-event-store-8c751c47db6f,The Design of an Event Store. The road beyond event sourcing | Towards Data Science
+2021-03-12,https://curity.medium.com/jwts-and-how-to-use-them-5a31d3a3759b,JWTs and how to use them | Curity
+2021-03-12,https://github.com/roapi/roapi,GitHub - roapi/roapi: Create full-fledged APIs for static datasets without writing a single line of code
+2021-03-12,https://pronovix.com/blog/which-api-management-tool,Which API management tool? | PronovixPronovix_logo_developerPronovix_logo_developer
+2021-03-12,https://www.notboring.co/p/apis-all-the-way-down,APIs All the Way Down - Not Boring
+2021-03-19,https://darutk.medium.com/financial-grade-api-fapi-explained-by-an-implementer-d09fcf2ff932,"Financial-grade API (FAPI), explained by an implementer"
+2021-03-19,https://emmaparnell.medium.com/lets-talk-about-sex-6bb64c7e8f0c,Let’s talk about sex*
+2021-03-19,https://nordicapis.com/challenges-the-api-industry-faces-in-2021/,Challenges the API Industry Faces in 2021 | Nordic APIs
+2021-03-19,https://openid.net/2021/03/12/fapi-1-0-part-1-and-part-2-are-now-final-specifications/,FAPI 1.0 Part 1 and Part 2 are now Final Specifications | OpenID
+2021-03-19,https://the-api-collective.com/,The API Collective - A List of Free and Public APIs
+2021-03-19,https://twitter.com/worddoodles_EP/status/1372903483679109120,Last night the gender question was removed from the vaccine booking service hosted on NHS...
+2021-03-19,https://www.asyncapi.com/blog/governance-motivation,Finding a Good Open Governance Model for AsyncAPI | AsyncAPI Initiative for event-driven APIs
+2021-03-26,https://apievangelist.com/2021/03/25/setting-a-baseline-api-lifecycle-definition/,Setting a Baseline API Lifecycle Definition
+2021-03-26,https://blog.postman.com/the-future-of-graphql/,The Future of GraphQL | Postman Blog
+2021-03-26,https://www.computing.co.uk/opinion/4027919/reaping-rewards-graphql,Reaping the rewards of GraphQL: How to minimise pain points of implementation
+2021-03-26,https://www.youtube.com/watch?v=eu2n1i899rk,Introducing GraphQL in Large Organizations: Is API Governance Creating Monocultures?
+2021-04-01,https://blog.cloudflare.com/api-abuse-detection/,Announcing API Abuse Detection
+2021-04-01,https://nordicapis.com/api-first-companies-the-next-generation/,API-First Companies: The Next Generation | Nordic APIs
+2021-04-01,https://stoplight.io/blog/api-design-workflow-webinar-recap/,A Practical Guide to API Design-First
+2021-04-01,https://www.getpinwheel.com/blog/how-we-launched-api-docs-without-writing-api-docs,Tech spotlight: How we re-launched our API docs without actually writing API docs
+2021-04-09,https://blog.container-solutions.com/api-versioning-what-is-it-why-so-hard,API Versioning: What Is It and Why Is It So Hard?
+2021-04-09,https://fusionauth.io/learn/expert-advice/oauth/modern-guide-to-oauth/,The Modern Guide to OAuth - FusionAuth
+2021-04-09,https://github.blog/2021-04-05-how-we-scaled-github-api-sharded-replicated-rate-limiter-redis/,"How we scaled the GitHub API with a sharded, replicated rate limiter in Redis | The GitHub Blog"
+2021-04-09,https://tyk.io/a-case-study-in-api-platform-growth/,A Case Study in API Platform Growth - Tyk API Gateway and API Management
+2021-04-23,https://api.gov.uk/graphql,DRAFT | Using GraphQL for your API
+2021-04-23,https://apitracker.io/,Discover the best APIs and SaaS products | API Tracker
+2021-04-23,https://cloud.google.com/blog/products/api-management/understanding-grpc-openapi-and-rest-and-when-to-use-them,"gRPC vs REST: Understanding gRPC, OpenAPI and REST and when to use them in API design | Google Cloud Blog"
+2021-04-23,https://community.ibm.com/community/user/integration/blogs/dale-lane1/2021/04/19/other-ways-to-use-asyncapi-documents,Other ways to use AsyncAPI documents
+2021-04-23,https://stoplight.io/blog/how-many-apis-are-we-running-in-production/,How Many APIs Are We Running in Production?
+2021-04-23,https://stoplight.io/podcast/,"The API Intersection podcast, hosted by Jason Harmon | Stoplight"
+2021-04-23,https://www.asyncapi.com/blog/websocket-part1,"WebSocket, Shrek, and AsyncAPI - An Opinionated Intro | AsyncAPI Initiative for event-driven APIs"
+2021-04-30,https://apihandyman.io/this-is-not-the-http-method-you-re-looking-for-http-status-code-404-vs-405-vs-501/,"API Handyman | This is not the HTTP method you're looking for, HTTP status code 404 vs 405 vs 501"
+2021-04-30,https://portswigger.net/web-security/oauth,OAuth 2.0 authentication vulnerabilities | Web Security Academy
+2021-04-30,https://stoplight.io/blog/how-to-bring-design-first-apis-to-your-organization/,How to Bring Design-First APIs to Your Organization
+2021-04-30,https://stories.platformdesigntoolkit.com/design-apis-for-disobedience-7894f930e2cc,Design APIs for Disobedience. Components & Platforms to Empower… | Stories of Platform Design
+2021-05-07,https://blog.stoplight.io/security-practices-the-key-to-scaling-your-api-strategy/,Security Practices: The Key to Scaling Your API Strategy
+2021-05-07,https://blog.vnaik.com/posts/web-attacks.html,"CSRF, CORS, and HTTP Security headers Demystified"
+2021-05-07,https://krebsonsecurity.com/2021/04/experian-api-exposed-credit-scores-of-most-americans/,Experian API Exposed Credit Scores of Most Americans – Krebs on Security
+2021-05-07,https://nordicapis.com/11-space-apis-because-space-is-neat/,"11 Space APIs, Because Space is Neat | Nordic APIs"
+2021-05-07,https://resurface.io/blog/api-security-put-the-sec-in-devsecops,API Security: Put the Sec in DevSecOps — Resurface
+2021-05-10,http://designresearch.works/chi2021-hdi-workshop/a-manifesto.html,A Manifesto For HDI Research
+2021-05-14,https://5arkovacevic.medium.com/is-this-the-right-http-response-code-ad7117ee34da,Is This the Right HTTP Response Code?
+2021-05-14,https://api.gov.uk/apim,DRAFT | API Management Guidance
+2021-05-14,https://blog.stoplight.io/api-design-and-governance-problems-are-not-always-technical/,API Design and Governance Problems Are Not Always Technical
+2021-05-14,https://medium.com/null-exception/graphql-what-why-and-how-with-dotnet-core-73a3a5109f67,"GraphQL: What, Why and How with Dotnet Core | Null Exception"
+2021-05-14,https://nordicapis.com/11-tips-for-creating-an-api-style-guide/,11 Tips for Creating an API Style Guide | Nordic APIs
+2021-05-14,https://www.pentestpartners.com/security-blog/tour-de-peloton-exposed-user-data/,Tour de Peloton: Exposed user data | Pen Test Partners
+2021-05-14,https://www.theverge.com/2021/5/5/22421329/peloton-api-bug-customer-data-exposed,A bug in Peloton’s API may have exposed a whole lot of user data - The Verge
+2021-05-21,https://f.hubspotusercontent40.net/hubfs/440197/Cloud-Elements-2021-SOAI.pdf,The State of API Integration Report 2021
+2021-05-21,https://nordicapis.com/expect-the-unexpected-the-rise-of-functional-attacks/,Expect the Unexpected: The Rise of Functional Attacks | Nordic APIs
+2021-05-21,https://tech.ebayinc.com/engineering/asyncapi-2-0-enabling-the-event-driven-world/,AsyncAPI 2.0: Enabling the Event-Driven World
+2021-05-21,https://www.asyncapi.com/blog/websocket-part3,From API-First to Code Generation - A WebSocket Use Case | AsyncAPI Initiative for event-driven APIs
+2021-05-21,https://www.infoq.com/news/2021/05/ebay-adopts-asyncapi/,eBay Adopts AsyncAPI for Asynchronous API Contracts
+2021-05-28,https://blog.routable.com/whats-next-for-our-api/,What's next for the Routable API?
+2021-05-28,https://cybernews.com/security/report-how-cybercriminals-abuse-api-keys-to-steal-millions/,Report: how cybercriminals abuse API keys to steal millions
+2021-05-28,https://dzone.com/articles/hands-on-with-spectral-api-linting,Hands-on With Spectral: Using API Linting for Better API Design and Governance [Video] - DZone Integration
+2021-05-28,https://eng.uber.com/architecture-api-gateway/,The Architecture of Uber's API gateway - Uber Engineering BlogUber Engineering
+2021-05-28,https://www.dnd5eapi.co/,D&D 5th Edition API
+2021-06-11,https://apihandyman.io/6-reasons-why-generating-openapi-from-code-when-designing-and-documenting-apis-sucks/,API Handyman | 6 reasons why generating OpenAPI from code when designing and documenting APIs sucks
+2021-06-11,https://dwpdigital.blog.gov.uk/2021/05/24/podcast-what-are-apis-and-how-do-you-use-them/,Podcast: What are APIs and how do you use them? - DWP Digital
+2021-06-11,https://insidebigdata.com/2021/05/29/apis-the-real-ml-pipeline-everyone-should-be-talking-about/,APIs: The Real ML Pipeline Everyone Should Be Talking About - insideBIGDATA
+2021-06-11,https://nordicapis.com/a-guide-to-api-first-design/,A Guide to API-First Design | Nordic APIs
+2021-06-11,https://nordicapis.com/everything-you-need-to-know-about-api-versioning/,Everything You Need to Know About API Versioning | Nordic APIs
+2021-06-25,https://medium.com/geekculture/the-api-economy-2ea9d3e10d72,The API Economy. The sudden emergence of the API economy… | Geek Culture
+2021-06-30,https://restoreprivacy.com/linkedin-data-leak-700-million-users/,New LinkedIn Data Leak Leaves 700 Million Users Exposed - RestorePrivacy
+2021-07-02,https://apisyouwonthate.com/blog/understanding-rpc-rest-and-graphql,"Understanding RPC, REST and GraphQL | APIs You Won't Hate"
+2021-07-02,https://nordicapis.com/10-api-economy-terms-you-should-know/,10 API Economy Terms You Should Know | Nordic APIs
+2021-07-02,https://smizell.com/posts/2021/06/moving-from-high-to-low-schema-entropy/,Moving From High to Low Schema Entropy - Stephen Mizell
+2021-07-02,https://techcrunch.com/2021/07/01/months-later-were-still-making-sense-of-the-supreme-courts-api-copyright-ruling/,"Months later, we’re still making sense of the Supreme Court’s API copyright ruling – TechCrunchShare on Twitter"
+2021-07-09,http://mamund.site44.com/talks/2021-06-apis-of-the-future/,APIs of the Future : Are You Ready?
+2021-07-09,http://www.gentlydownthe.stream/,Gently Down the Stream
+2021-07-09,https://nordicapis.com/center-of-excellence-coe-vs-center-of-enablement-c4e/,Center of Excellence (CoE) vs. Center of Enablement (C4E) | Nordic APIs
+2021-07-09,https://stoplight.io/blog/what-makes-a-great-developer-portal/,What Makes a Great Developer Portal?
+2021-07-09,https://www.swyx.io/api-economy/,The Light and Dark Side of the API Economy
+2021-07-09,https://www.zdnet.com/article/apis-microservices-succeed-as-long-as-the-organization-doesnt-get-in-the-way/,"APIs, microservices succeed as long as the organization doesn't get in the way | ZDNet"
+2021-07-16,https://apievangelist.com/2021/07/13/seeing-api-change/,Seeing API Change
+2021-07-16,https://apihandyman.io/reading-thoughtworks-technology-radar-24/,API Handyman | Adopt and not assess OpenAPI linters and other thoughts reading Thoughtworks Technology Radar 24
+2021-07-16,https://nordicapis.com/8-unexpected-challenges-of-running-an-api-as-a-product/,8 Unexpected Challenges of Running an API-as-a-Product | Nordic APIs
+2021-07-16,https://nordicapis.com/ebook-released-api-as-a-product/,eBook Released: API-as-a-Product | Nordic APIs
+2021-07-16,https://thenextweb.com/news/open-apis-are-the-sexiest-thing-to-ever-happen-to-government-services,Open APIs are the sexiest thing to ever happen to government services
+2021-07-16,https://www.youtube.com/watch?v=Il5btHG_D74,Hands-On With Spectral: Using API Linting for Better API Design and API Governance
+2021-07-16,https://www.youtube.com/watch?v=MtAPj230BbI,Apidays LIVE interface 2021 - Human Centered API Governance By Arnaud Lauret
+2021-07-23,https://devops.com/a-funny-thing-happened-on-the-way-to-api-management/,A Funny Thing Happened On the Way to API Management - DevOps.com
+2021-07-23,https://shopify.engineering/rate-limiting-graphql-apis-calculating-query-complexity,Rate Limiting GraphQL APIs by Calculating Query Complexity — Development (2021)
+2021-07-23,https://www.infoq.com/podcasts/asyncapi/,Fran Méndez on AsyncAPI
+2021-07-23,https://www.talkabouttechpodcast.com/1712587/8862439-from-technical-stories-to-user-stories-apis-and-the-evolution-of-the-tech-industry-with-lorinda-brandon-and-mike-amundsen,From technical stories to user stories: APIs and the evolution of the tech industry with Lorinda Brandon and Mike Amundsen
+2021-07-30,http://apihandyman.io/an-api-gateway-alone-will-not-secure-your-api/,API Handyman | An API Gateway alone will not secure your API
+2021-07-30,https://blog.axway.com/amplify-products/api-management/spectral-as-part-of-your-api-platform-and-your-api-governance,Spectral as part of your API platform and your API governance
+2021-07-30,https://nordicapis.com/api-expert-report-finds-increasing-overall-api-quality/,API.expert Report Finds Increasing Overall API Quality | Nordic APIs
+2021-07-30,https://tyk.io/the-six-hats-of-the-api-architect/,The Six Hats of the API Architect - Tyk API Gateway and API Management
+2021-08-06,https://blog.stoplight.io/why-you-should-view-your-apis-as-products,Why You Should View Your APIs as Products
+2021-08-06,https://devops.com/our-api-mess-is-coming/,Our API Mess is Coming - DevOps.com
+2021-08-06,https://www.gartner.com/en/documents/4004085,"Hype Cycle for APIs and Business Ecosystems, 2021"
+2021-08-06,https://www.youtube.com/watch?v=RexFqicHZrE,Apidays LIVE interface 2021 - 10 Keys for Turning APIs into a Job Promotion By Brenton House
+2021-08-06,https://www.youtube.com/watch?v=xqU3Efnd5G0&list=PLmEaqnTJ40Or6xpWGCX7Z9ej40fzGcd9g&index=7,Apidays LIVE interface 2021 - API First mentality By Tanya Vlahovic
+2021-08-13,https://securityboulevard.com/2021/08/developing-best-practices-for-api-security/,Developing Best Practices for API Security - Security Boulevard
+2021-08-13,https://slack.engineering/how-we-design-our-apis-at-slack/,How We Design Our APIs at Slack - Slack Engineering
+2021-08-13,https://tyk.io/a-case-study-in-api-platform-growth/,A Case Study in API Platform Growth - Tyk API Gateway and API Management
+2021-08-13,https://www.mnot.net/blog/2021/06/21/standards-competition-governance,mnot’s blog: How the Next Layer of the Internet is Going to be Standardised
+2021-08-13,https://www.torryharris.com/blog/5-key-challenges-governance-can-help-firms-face-on-their-digital-transformation-journeys,Top 5 digital transformation challenges that governance can help
+2021-08-20,https://blog.stoplight.io/api-first-vs.-api-design-first-a-comprehensive-guide,API-First vs. API Design-First: A Comprehensive Guide
+2021-08-20,https://developer.salesforce.com/blogs/2021/08/make-api-version-retirements-a-no-op,Salesforce DevelopersMake API Version Retirements a No-Op | Salesforce Developers Blog
+2021-08-20,https://hackernoon.com/nerds-dont-respond-to-marketing-try-technical-documentation-instead,Nerds Don't Respond To Marketing; Try Technical Documentation Instead | Hacker Noon
+2021-08-20,https://thenewstack.io/api-technology-trends-in-2021/,API Technology Trends in 2021 – The New Stack
+2021-08-20,https://www.akitasoftware.com/blog-posts/the-software-heterogeneity-problem-or-why-we-didnt-build-on-graphql,"The Software Heterogeneity Problem, or Why We Didn't Build on GraphQL — Akita Software"
+2021-08-20,https://www.infoq.com/articles/github-monolith-microservices/,GitHub’s Journey from Monolith to Microservices
+2021-08-27,https://blog.postman.com/what-we-learned-from-200000-openapi-files/,"What We Learned from 200,000 OpenAPI Files | Postman Blog"
+2021-08-27,https://labs.detectify.com/2021/08/10/how-to-hack-apis-in-2021/,How to Hack APIs in 2021 by Hakluke and Farah Hawa | Detectify Labs
+2021-08-27,https://matthewreinbold.com/2021/08/18/OneWayToImproveAPIGuidance/,One Way to Improve API Guidance
+2021-08-27,https://nordicapis.com/best-public-api-of-2021/,Best Public API of 2021 | Nordic APIs
+2021-08-27,https://nordicapis.com/whats-the-difference-between-rest-and-restful/,What's the Difference Between REST and RESTful? | Nordic APIs
+2021-09-10,https://apihandyman.io/an-api-design-review-is-based-on-facts-not-opinions/,"API Handyman | An API design review is based on facts, not opinions"
+2021-09-10,https://blog.stoplight.io/people-will-love-your-consistent-api-design,People Will Love Your Consistent API Design
+2021-09-10,https://nordicapis.com/api-specifications-calm-chaos-of-digital-transformation-part-2/,API Specifications Calm Chaos of Digital Transformation (Part 2) | Nordic APIs
+2021-09-10,https://nordicapis.com/top-oauth-api-vulnerabilities/,Top OAuth API Vulnerabilities | Nordic APIs
+2021-09-10,https://useoptic.com/blog/making-design-first-and-code-first-work-for-everyone/,Making Design First and Code First Work for Everyone | Optic
+2021-09-10,https://wundergraph.com/blog/the_complete_graphql_security_guide_fixing_the_13_most_common_graphql_vulnerabilities_to_make_your_api_production_ready,The complete GraphQL Security Guide: Fixing the 13 most common GraphQL Vulnerabilities to make your API production ready - WunderGraph
+2021-09-10,https://www.asyncapi.com/blog/openapi-vs-asyncapi-burning-questions,AsyncAPI vs OpenAPI: Answers to Your Burning Questions About Two Leading API Specs | AsyncAPI Initiative for event-driven APIs
+2021-09-17,https://apievangelist.com/2021/02/11/gathering-my-thoughts-on-api-discovery/,Gathering My Thoughts on API Discovery
+2021-09-17,https://fly.io/blog/api-tokens-a-tedious-survey/,API Tokens: A Tedious Survey · FlyFlyBlogFly
+2021-09-17,https://securityboulevard.com/2021/09/some-recent-api-security-related-gaffes-and-how-they-might-have-been-avoided/,"Some Recent API Security Related Gaffes, And How They Might Have Been Avoided - Security Boulevard"
+2021-09-17,https://www.infoq.com/news/2021/09/api-design-first-addr/,"API Design-First Using the ""Align-Define-Design-Refine"" Process"
+2021-09-24,https://apievangelist.com/2021/09/20/building-an-api-platform-that-will-support-the-future/,Building an API Platform That Will Support the Future
+2021-09-24,https://blog.dream11engineering.com/lessons-learned-from-running-graphql-at-scale-2ad60b3cefeb,"Lessons learned from running GraphQL at scale | Dream11 Engineering"
+2021-09-24,https://dataconnect.api.gov.uk/schedule,DataConnect21
+2021-09-24,https://nordicapis.com/graphql-microservices-gqlms-as-a-backend-a-netflix-case-study/,GraphQL Microservices (GQLMS) as a Backend: A Netflix Case Study | Nordic APIs
+2021-09-24,https://securityboulevard.com/2021/09/improving-development-and-security-collaboration-with-api-specification-frameworks/,Improving Development and Security Collaboration With API Specification Frameworks - Security Boulevard
+2021-09-24,https://www.adalovelaceinstitute.org/report/participatory-data-stewardship/,Participatory data stewardship | Ada Lovelace Institute
+2021-09-25,https://pautva.github.io/dd3-wireframes/,Designing geospatial data portals
+2021-10-08,https://blog.bitsrc.io/api-versioning-dos-and-don-ts-4bd9db073f2a,"API Versioning Do’s and Don’ts. It’s never too soon to get started… | Bits and Pieces"
+2021-10-08,https://blog.stoplight.io/drinking-api-design-first-champagne,Drinking API Design-First Champagne
+2021-10-08,https://cacm.acm.org/magazines/2021/3/250706-a-second-conversation-with-werner-vogels/fulltext,A Second Conversation with Werner Vogels
+2021-10-08,https://matthewreinbold.com/2021/10/01/WeMadeAnAPIDescription/,"We Made an API Description, Now What?"
+2021-10-08,https://smartbear.com/news/news-releases/smartbear-releases-results-of-2021-state-of-softwa/,SmartBear Releases Results of 2021 State of Software Quality | API Survey
+2021-10-08,https://www.gov.uk/guidance/using-graphql-for-your-api,Using GraphQL for your API - GOV.UK
+2021-10-08,https://www.lastweekinaws.com/blog/how-aws-dumps-the-mental-burden-of-inconsistent-apis-on-developers/,How AWS dumps the mental burden of inconsistent APIs on developers
+2021-10-10,https://blog.thegovlab.org/post/a-curation-of-tools-for-re-use,The Governance Lab
+2021-10-10,https://www.bloomberg.com/news/features/2021-09-25/why-every-government-needs-a-covid-dashboard,Bloomberg - Are you a robot?
+2021-10-15,https://blog.stoplight.io/is-your-organization-ready-to-build-apis-answer-these-3-questions-first,Is Your Organization Ready to Build APIs? Answer These 3 Questions First
+2021-10-15,https://expeditedsecurity.com/api-security-best-practices-megaguide/,API Security Best Practices MegaGuide
+2021-10-15,https://expeditedsecurity.com/whitepapers/API_Security_Best_Practices_MegaGuide.pdf,API Security Best Practices MegaGuide (PDF Download)
+2021-10-15,https://medium.com/@Growth_at_Wundergraph/graphql-is-not-meant-to-be-exposed-over-the-internet-f502a61a64d6,GraphQL is not meant to be exposed over the internet
+2021-10-15,https://securityboulevard.com/2021/10/apis-and-security-whats-a-security-officer-to-do/,APIs and Security: What's a Security Officer to Do? - Security Boulevard
+2021-10-15,https://www.pentestpartners.com/security-blog/free-brewdog-beer-with-a-side-order-of-shareholder-pii/,Free BrewDog beer with a side order of shareholder PII? | Pen Test Partners
+2021-10-22,https://building.brex.com/building-the-brex-api-52dcb26cacc8,"Building the Brex API. When we spoke to some of our power… | Building Brex"
+2021-10-22,https://httptoolkit.tech/blog/status-targeted-caching-headers/,New HTTP standards for caching on the modern web | HTTP Toolkit
+2021-10-22,https://nooshu.com/blog/2020/08/12/a-vary-unusual-waterfall/,A 'Vary' unusual waterfall - Matt Hobbs
+2021-10-22,https://tyk.io/blog/scaling-an-api-programme-through-api-coaching/,Scaling an API programme through API coaching - Tyk API Gateway and API Management
+2021-10-22,https://thttps://www.scmagazine.com/analysis/application-security/critical-flaws-found-in-interoperability-backbone-fhir-apis-vulnerable-to-abuse,Critical flaws found in interoperability backbone: FHIR APIs vulnerable to abuse
+2021-10-22,https://www.datacenterknowledge.com/security/api-attacks-breaches-piling,"API Attacks, Breaches Piling Up"
+2021-10-22,https://apihandyman.io/excuse-my-french-api-or-being-an-english-as-a-second-language-api-designer/,"Excuse my French API, or being an English as a second language API designer"
+2021-10-22,https://www.nature.com/articles/d41586-021-02693-2,Reboot AI with human values
+2021-10-29,https://aaronparecki.com/2019/12/12/21/its-time-for-oauth-2-dot-1,It's Time for OAuth 2.1 • Aaron Parecki
+2021-10-29,https://apihandyman.io/anarchy-in-the-resource-path/,API Handyman | Anarchy in the resource path
+2021-10-29,https://blog.assetnote.io/2021/04/05/contextual-content-discovery/,Contextual Content Discovery: You've forgotten about the API endpoints – Assetnote
+2021-10-29,https://cyberprotection-magazine.com/taking-charge-of-the-api-security-lifecycle/,Taking charge of the API security lifecycle - Cyber Protection Magazine
+2021-10-29,https://http.cat/,"HTTP Status Codes, as Cats"
+2021-10-29,https://levelup.gitconnected.com/how-to-use-openapi-for-secure-and-robust-api-integration-df1bb37b569d,"How to Use OpenAPI for Secure and Robust API Integration | Level Up Coding"
+2021-10-29,https://nordicapis.com/analyzing-trends-across-200000-openapi-files/,"Analyzing Trends Across 200,000 OpenAPI Files | Nordic APIs"
+2021-10-29,https://oauth.net/2.1/,OAuth 2.1
+2021-10-29,https://www.datatheorem.com/news/2021/data-theorem-intro-first-api-attack-surface-calculator,Data Theorem Introduces Industry’s First API Attack Surface Calculator
+2021-10-29,https://httpstatusdogs.com/,"HTTP Status Codes, as Dogs"
+2021-10-29,https://random-d.uk/http,"HTTP Status Codes, as Ducks"
+2021-10-29,https://changelog.com/podcast/456,"OAuth, ""It's complicated."""
+2021-10-29,https://www.jvt.me/posts/2021/01/05/why-content-negotiation/,Why I Consistently Reach for Server-Driven Content Negotiation (For Versioning)
+2021-10-29,https://curity.io/resources/learn/phantom-token-pattern/,The Phantom Token Approach

--- a/lib/links.rb
+++ b/lib/links.rb
@@ -1,0 +1,2 @@
+require_relative "links/link"
+require_relative "links/links"

--- a/lib/links/link.rb
+++ b/lib/links/link.rb
@@ -1,0 +1,15 @@
+require "active_model"
+
+class Link
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Validations
+
+  attribute :date_added, :date
+  attribute :url, :string
+  attribute :title, :string
+
+  validates :date_added, presence: true
+  validates :url, presence: true
+  validates :title, presence: true
+end

--- a/lib/links/links.rb
+++ b/lib/links/links.rb
@@ -1,0 +1,20 @@
+require_relative "link"
+require_relative "../csv_source"
+
+class Links
+  def self.from_csv(links_csv)
+    links = CsvSource.load(links_csv) { |attributes| Link.new(attributes) }
+    new(links)
+  end
+
+  attr_reader :links, :all_links
+
+  def initialize(links)
+    @links = links.select(&:valid?)
+    @all_links = links
+  end
+
+  def by_date
+    links.group_by(&:date_added)
+  end
+end

--- a/lib/url_helpers.rb
+++ b/lib/url_helpers.rb
@@ -8,4 +8,18 @@ module_function
   def api_path(organisation:, api:)
     "/#{organisation.slug}/#{api.slug}/index.html"
   end
+
+  def append_querystring(uri, add)
+    parsed = URI.parse(uri)
+    qs = query_to_hash(parsed.query)
+    qs.merge!(add)
+    parsed.query = URI.encode_www_form(qs)
+    parsed.to_s
+  end
+
+  def query_to_hash(query)
+    return {} unless query
+
+    CGI.parse(query).transform_values(&:first)
+  end
 end

--- a/source/resources/index.html.md
+++ b/source/resources/index.html.md
@@ -1,0 +1,9 @@
+---
+title: Resources
+weight: 1
+---
+# Supporting Resources
+
+Implementers and integrators with the UK Government APIs may also want to look at the following resources:
+
+- [Links](/resources/links/)

--- a/source/resources/links/feed.xml.builder
+++ b/source/resources/links/feed.xml.builder
@@ -1,0 +1,30 @@
+xml.instruct!
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
+  site_url = config[:tech_docs][:host]
+  xml.title "UK Government API and Data Exchange Community Slack Community Links"
+  xml.subtitle "Links of interest, being discussed by the UK Government API Community on https://ukgovtapidx.slack.com/"
+  xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
+  xml.updated(links.links.first.date_added.to_time.iso8601) unless links.links
+  xml.author do
+    xml.name "UK Government API Community"
+    xml.uri config[:tech_docs][:host]
+    xml.email "api-programme@digital.cabinet-office.gov.uk"
+  end
+
+  links.links.each do |link|
+    tracking_url = append_querystring(link.url, {
+      utm_source: "api.gov.uk",
+      utm_medium: "rss",
+    })
+    content = <<-DOC
+    <a href="#{tracking_url}">#{link.url}</a> was shared in the <a href="https://ukgovtapidx.slack.com/">UK Government API and Data Exchange Community Slack</a>
+    DOC
+    xml.entry do
+      xml.title link.title
+      xml.link "rel" => "alternate", "href" => link.url
+      xml.id link.url
+      xml.published link.date_added.to_time.iso8601
+      xml.content content, "type" => "html"
+    end
+  end
+end

--- a/source/resources/links/index.html.md.erb
+++ b/source/resources/links/index.html.md.erb
@@ -1,0 +1,29 @@
+---
+title: Recommended Reading (Archive)
+weight: 1
+---
+# Recommended Reading (Archive)
+
+In the [UK Government API and Data Exchange Community Slack Community](https://ukgovtapidx.slack.com/) there are a number of interesting links that our community shares and discusses in the [`#links` channel](https://ukgovtapidx.slack.com/archives/C01JZTF1VU4).
+
+This page is an archive to provide a handy way of looking back at the resources we've shared, but doesn't include any additional context or discussion. We'd recommend joining the community, which can be done by either [emailing us](mailto:api-programme@digital.cabinet-office.gov.uk) for an invite, or letting us know in the [`#apis` channel in the X-Government Slack](https://ukgovernmentdigital.slack.com/archives/C41GC5UAY).
+
+You can also subscribe to this page's <a rel="alternate" href="/resources/links/feed.xml">RSS Feed</a>.
+
+<% links.by_date.reverse_each do |i, links| %>
+# <%= i.strftime('%d %B %Y') %>
+
+<ul>
+  <% links.each do |link| %>
+    <li>
+      <%
+          tracking_url = append_querystring(link.url, {
+            utm_source: "api.gov.uk",
+            utm_medium: "direct",
+          })
+        %>
+      <a href="<%= tracking_url %>"><%= link.title %></a>
+    </li>
+  <% end %>
+</ul>
+<% end %>

--- a/spec/lib/url_helpers_spec.rb
+++ b/spec/lib/url_helpers_spec.rb
@@ -1,0 +1,46 @@
+require "url_helpers"
+
+RSpec::Matchers.define :have_same_querystring do |expected|
+  match do |actual|
+    CGI.parse(URI.parse(expected).query) == CGI.parse(URI.parse(actual).query)
+  end
+end
+
+RSpec.describe "UrlHelpers" do
+  describe "append_querystring" do
+    [nil, "", "http", "https://foo&bar=baz"].each do |_value|
+      it "does not support invalid URIs" do
+        expect { UrlHelpers.append_querystring(nil, nil) }.to raise_error(URI::InvalidURIError)
+      end
+    end
+
+    it "creates querystring if not present" do
+      url = "https://url"
+      to_add = {
+        utm: "foo",
+      }
+      expect(UrlHelpers.append_querystring(url, to_add)).to have_same_querystring "https://url?utm=foo"
+    end
+
+    it "appends to existing querystring if present" do
+      url = "https://blog?post=1234"
+      to_add = {
+        add: "foo",
+      }
+      expect(UrlHelpers.append_querystring(url, to_add)).to have_same_querystring "https://blog?add=foo&post=1234"
+    end
+
+    it "ignores everything but the first querystring parameter" do
+      url = "https://blog?foo=1234&foo=2345"
+      to_add = {
+        add: "foo",
+      }
+      expect(UrlHelpers.append_querystring(url, to_add)).to have_same_querystring "https://blog?add=foo&foo=1234"
+    end
+
+    it "doesn't require query to override" do
+      url = "https://blog?foo=1234"
+      expect(UrlHelpers.append_querystring(url, {})).to have_same_querystring url
+    end
+  end
+end


### PR DESCRIPTION
To better serve the X-Government API community - in-and-out of our Slack
community - as well as providing some interesting resources for the
private sector, we should publish our interesting links publicly.

This produces both an HTML frontend and an RSS feed, so folks have
options for keeping up-to-date on what's available and being published.

This requires a new CSV data source, and:

- we can utilise the `builder` gem to more easily build up our Atom
  (RSS) feed
- we make sure to add `rel=alternate` to allow for automagic detection
  by feed readers
- add a new `Link` + `Links` class to contain the ?.
- add validation through Active Model for the `Link` class, to perform
  batteries-included validation
- add a Rake task to validate that the link data is well-formed, with a
  `schema` namespace + task to make it easier to validate more in the
  future
- add a helper for
- add a `/resources/` page as a parent, for any other informative
  resources
- backfill links
- add helper for querystring appending

Example:

- [Archive preview](https://distracted-goodall-a881ff.netlify.app/resources/links/)
- [RSS Feed preview](https://monocle.p3k.io/preview?url=https%3A%2F%2Fdistracted-goodall-a881ff.netlify.app/resources%2Flinks%2Ffeed.xml)