### PR TITLE
Amend API Links page for better accessibility

### DIFF
--- a/source/resources/links/index.html.md.erb
+++ b/source/resources/links/index.html.md.erb
@@ -2,7 +2,7 @@
 title: Recommended Reading (Archive)
 weight: 1
 ---
-# Recommended Reading (Archive)
+# Recommended reading (archive)
 
 In the [UK Government API and Data Exchange Community Slack Community](https://ukgovtapidx.slack.com/) there are a number of interesting links that our community shares and discusses in the [`#links` channel](https://ukgovtapidx.slack.com/archives/C01JZTF1VU4).
 

--- a/source/resources/links/index.html.md.erb
+++ b/source/resources/links/index.html.md.erb
@@ -11,7 +11,7 @@ This page is an archive to provide a handy way of looking back at the resources 
 You can also subscribe to this page's <a href="/resources/links/feed.xml">RSS Feed</a>.
 
 <% links.by_date.reverse_each do |i, links| %>
-# <%= i.strftime('%d %B %Y') %>
+## <%= i.strftime('%d %B %Y') %>
 
 <ul>
   <% links.each do |link| %>


### PR DESCRIPTION
- Don't use title case for `h1`s
- Use `h2`s for additional headers
