### PR TITLE
Update recommended reading

### DIFF
--- a/source/resources/links/index.html.md.erb
+++ b/source/resources/links/index.html.md.erb
@@ -1,14 +1,14 @@
 ---
-title: Recommended Reading (Archive)
+title: API community links
 weight: 1
 ---
-# Recommended reading (archive)
+# API community links
 
-In the [UK Government API and Data Exchange Community Slack Community](https://ukgovtapidx.slack.com/) there are a number of interesting links that our community shares and discusses in the [`#links` channel](https://ukgovtapidx.slack.com/archives/C01JZTF1VU4).
+This page contains an archived list of links shared in the [UK Government API and Data Exchange Community Slack](https://ukgovtapidx.slack.com/) by people in the cross-government API community. The list includes links to websites outside of the public sector such as software company websites and personal blogs.
 
-This page is an archive to provide a handy way of looking back at the resources we've shared, but doesn't include any additional context or discussion. We'd recommend joining the community, which can be done by either [emailing us](mailto:api-programme@digital.cabinet-office.gov.uk) for an invite, or letting us know in the [`#apis` channel in the X-Government Slack](https://ukgovernmentdigital.slack.com/archives/C41GC5UAY).
+To request to join the cross-government API and Data Exchange Community Slack, [email us](mailto:api-programme@digital.cabinet-office.gov.uk) or [contact us in the `#apis` channel of the cross-government Slack community](https://ukgovernmentdigital.slack.com/archives/C41GC5UAY).
 
-You can also subscribe to this page's <a href="/resources/links/feed.xml">RSS Feed</a>.
+You can also <a href="/resources/links/feed.xml">subscribe to this page's RSS feed</a>.
 
 <% links.by_date.reverse_each do |i, links| %>
 ## <%= i.strftime('%d %B %Y') %>


### PR DESCRIPTION
A few changes to make this a bit more GOV-y:

- change title to be more neutral/opinionated (for example, we shouldn't call it 'recommended' reading as there's no context for why we would recommend it)
- clarified that the list also includes non-public sector links
- be a little less conversational/narrative and more user-focused/task-focused
- general style applied