### PR TITLE
Fix: Add checkout before `setup-ruby`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v2
+
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
Fix for 188842b9ce16ce30eac7aefe99b7daaf54b8f593, as `setup-ruby` needs
to know from the contents of the `.ruby-version` file.
