### PR TITLE
Fix: Download built site to the `build` directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: site
+          path: build
 
       # Checkout stripped-down gh-pages branch to a subdirectory, for publishing
       - name: Checkout gh-pages branch


### PR DESCRIPTION
As our Rake tasks expect it to be there.

Fixup for 188842b9ce16ce30eac7aefe99b7daaf54b8f593.
